### PR TITLE
feat(responsivo): ajustar layout mobile no admin e eventos

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1373,7 +1373,7 @@ section {
   }
 
   .eventos-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: 1fr;
     gap: 1rem;
     padding: 0 1rem;
   }

--- a/src/admin/Admin.css
+++ b/src/admin/Admin.css
@@ -856,6 +856,8 @@
 
   .admin-topbar {
     padding: 1rem;
+    flex-wrap: wrap;
+    gap: 0.75rem;
   }
 
   .admin-content {
@@ -870,11 +872,127 @@
     grid-template-columns: 1fr;
   }
 
-  .events-table th:nth-child(4),
-  .events-table td:nth-child(4),
-  .events-table th:nth-child(5),
-  .events-table td:nth-child(5) {
+  .events-section {
+    padding: 1rem;
+  }
+
+  .events-section .section-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .events-section .section-header .btn-primary {
+    width: 56px;
+    height: 56px;
+    padding: 0;
+    border-radius: 0.75rem;
+    gap: 0;
+    justify-content: center;
+    position: fixed;
+    right: 1.25rem;
+    bottom: 1.25rem;
+    z-index: 900;
+    box-shadow: 0 12px 24px var(--shadow);
+  }
+
+  .events-section .section-header .btn-primary .btn-text {
     display: none;
+  }
+
+  .events-section .section-header .btn-primary svg {
+    margin: 0;
+  }
+
+  .events-table-container {
+    overflow: visible;
+  }
+
+  .events-table {
+    border-collapse: separate;
+    border-spacing: 0 0.75rem;
+  }
+
+  .events-table thead {
+    display: none;
+  }
+
+  .events-table tbody,
+  .events-table tr,
+  .events-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .events-table tr {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .events-table td {
+    border: none;
+    padding: 0.5rem 0;
+  }
+
+  .events-table td::before {
+    content: attr(data-label);
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.35rem;
+  }
+
+  .events-table td[data-label='Horário'],
+  .events-table td[data-label='Período'] {
+    display: inline-block;
+    width: calc(50% - 0.25rem);
+    vertical-align: top;
+  }
+
+  .events-table td[data-label='Horário'] {
+    margin-right: 0.5rem;
+  }
+
+  .events-table td:last-child {
+    padding-bottom: 0;
+  }
+
+  .event-thumbnail {
+    width: 100%;
+    height: 140px;
+    border-radius: 0.5rem;
+  }
+
+  .event-desc-preview {
+    max-width: none;
+    white-space: normal;
+  }
+
+  .action-buttons {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+  }
+
+  .btn-icon {
+    width: 100%;
+    height: 40px;
+  }
+
+  .notification {
+    right: 1rem;
+    left: 1rem;
+  }
+
+  .modal-overlay {
+    padding: 1rem;
   }
 }
 

--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   LayoutDashboard,
@@ -123,6 +123,25 @@ function Dashboard() {
     formState: { errors },
   } = useForm()
 
+  const showNotification = useCallback((message, type = 'success') => {
+    setNotification({ message, type })
+    setTimeout(() => setNotification(null), 3000)
+  }, [])
+
+  const loadEvents = useCallback(async () => {
+    try {
+      setLoading(true)
+      const [eventsData, statsData] = await Promise.all([getEvents(), getEventStats()])
+      setEventos(eventsData)
+      setStats(statsData)
+    } catch (error) {
+      console.error('Erro ao carregar eventos:', error)
+      showNotification('Erro ao carregar eventos', 'error')
+    } finally {
+      setLoading(false)
+    }
+  }, [showNotification])
+
   useEffect(() => {
     async function init() {
       const session = await getSession()
@@ -146,21 +165,7 @@ function Dashboard() {
     }
 
     init()
-  }, [navigate])
-
-  const loadEvents = async () => {
-    try {
-      setLoading(true)
-      const [eventsData, statsData] = await Promise.all([getEvents(), getEventStats()])
-      setEventos(eventsData)
-      setStats(statsData)
-    } catch (error) {
-      console.error('Erro ao carregar eventos:', error)
-      showNotification('Erro ao carregar eventos', 'error')
-    } finally {
-      setLoading(false)
-    }
-  }
+  }, [navigate, loadEvents])
 
   const toggleTheme = () => {
     const newTheme = !isDarkMode
@@ -183,11 +188,6 @@ function Dashboard() {
       console.error('Erro ao fazer logout:', error)
       showNotification('Erro ao fazer logout', 'error')
     }
-  }
-
-  const showNotification = (message, type = 'success') => {
-    setNotification({ message, type })
-    setTimeout(() => setNotification(null), 3000)
   }
 
   const openCreateModal = () => {
@@ -427,9 +427,9 @@ function Dashboard() {
           <div className="events-section">
             <div className="section-header">
               <h2>Eventos Cadastrados</h2>
-              <button className="btn-primary" onClick={openCreateModal}>
+              <button className="btn-primary" onClick={openCreateModal} aria-label="Novo Evento">
                 <Plus size={18} />
-                Novo Evento
+                <span className="btn-text">Novo Evento</span>
               </button>
             </div>
 
@@ -460,27 +460,27 @@ function Dashboard() {
                   <tbody>
                     {eventos.map((evento) => (
                       <tr key={evento.id}>
-                        <td>
+                        <td data-label="Imagem">
                           <img
                             src={evento.imagem || BgEventos}
                             alt={evento.nome}
                             className="event-thumbnail"
                           />
                         </td>
-                        <td>
+                        <td data-label="Nome do Evento">
                           <span className="event-name">{evento.nome}</span>
                           {evento.descricao && (
                             <span className="event-desc-preview">{evento.descricao}</span>
                           )}
                         </td>
-                        <td>{evento.data_evento}</td>
-                        <td>{evento.horario}</td>
-                        <td>
+                        <td data-label="Data">{evento.data_evento}</td>
+                        <td data-label="Horário">{evento.horario}</td>
+                        <td data-label="Período">
                           <span className={`badge badge-${evento.periodo?.toLowerCase()}`}>
                             {evento.periodo}
                           </span>
                         </td>
-                        <td>
+                        <td data-label="Ações">
                           <div className="action-buttons">
                             <button
                               className="btn-icon btn-view"

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -13,8 +13,7 @@ function Contact() {
     reset,
   } = useForm()
 
-  const onSubmit = (data) => {
-    console.log('Formulario enviado:', data)
+  const onSubmit = (_data) => {
     alert('Mensagem enviada com sucesso!')
     reset()
   }


### PR DESCRIPTION
- deixa cards de eventos com 1 coluna no mobile

- torna lista do admin responsiva com cards e ações em linha

- adiciona botão flutuante de novo evento no mobile