### PR TITLE
fix(pagination): rola para o topo ao mudar de página

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -111,6 +111,11 @@ function App() {
   const pageOffset = (currentPage - 1) * pageSize
 
   useEffect(() => {
+    // Rola a pagina para o topo sempre que a pagina atual mudar
+    window.scrollTo(0, 0)
+  }, [currentPage])
+
+  useEffect(() => {
     const observerOptions = {
       threshold: 0.3,
       rootMargin: '-50px 0px',


### PR DESCRIPTION
Garante que a visualização de eventos volte ao topo da página sempre que o usuário navegar para uma nova página de resultados na paginação.

Isso melhora a experiência do usuário, evitando que ele precise rolar manualmente para cima.