### PR TITLE
fix(seo): corrige meta tags open graph para preview em redes sociais

### DIFF
--- a/api/og.ts
+++ b/api/og.ts
@@ -1,7 +1,7 @@
 const SITE_NAME = 'Eventos - Comunidade Café Bugado'
 const DEFAULT_DESCRIPTION =
   'Descubra os melhores eventos de tecnologia. Meetups, workshops, hackathons e conferências reunidos em um só lugar pela comunidade.'
-const DEFAULT_IMAGE = '/eventos.png'
+const DEFAULT_IMAGE_PATH = '/eventos.png'
 
 const PAGE_SEO: Record<string, { title: string; description: string }> = {
   '/': {
@@ -32,10 +32,19 @@ const CRAWLER_USER_AGENTS = [
   'LinkedInBot',
   'WhatsApp',
   'Slackbot',
+  'Slack-ImgProxy',
   'TelegramBot',
   'Discordbot',
   'Applebot',
   'Pinterest',
+  'Googlebot',
+  'bingbot',
+  'Embedly',
+  'Quora Link Preview',
+  'Showyoubot',
+  'vkShare',
+  'redditbot',
+  'Skype',
 ]
 
 function isCrawler(userAgent: string | null): boolean {
@@ -48,6 +57,12 @@ function stripHtmlTags(html: string | null): string {
   if (!html) return ''
   return html
     .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
     .replace(/\s+/g, ' ')
     .trim()
 }
@@ -57,20 +72,39 @@ function truncateText(text: string | null, maxLength = 160): string {
   return text.substring(0, maxLength - 3) + '...'
 }
 
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 function generateHtml({
   title,
   description,
   image,
   url,
   type = 'website',
+  publishedTime,
 }: {
   title: string
   description: string
   image: string
   url: string
   type?: string
+  publishedTime?: string
 }): string {
-  const fullTitle = title !== SITE_NAME ? `${title} | ${SITE_NAME}` : title
+  const fullTitle =
+    title !== SITE_NAME ? `${escapeHtml(title)} | ${SITE_NAME}` : SITE_NAME
+  const safeTitle = escapeHtml(title)
+  const safeDescription = escapeHtml(description)
+
+  let articleTags = ''
+  if (type === 'article' && publishedTime) {
+    articleTags = `\n  <meta property="article:published_time" content="${escapeHtml(publishedTime)}">`
+  }
 
   return `<!DOCTYPE html>
 <html lang="pt-BR">
@@ -78,22 +112,25 @@ function generateHtml({
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${fullTitle}</title>
-  <meta name="description" content="${description}">
+  <meta name="description" content="${safeDescription}">
 
-  <!-- Open Graph / Facebook -->
+  <!-- Open Graph / Facebook / WhatsApp / LinkedIn / Telegram / Discord -->
   <meta property="og:type" content="${type}">
   <meta property="og:url" content="${url}">
-  <meta property="og:title" content="${title}">
-  <meta property="og:description" content="${description}">
+  <meta property="og:title" content="${safeTitle}">
+  <meta property="og:description" content="${safeDescription}">
   <meta property="og:image" content="${image}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
   <meta property="og:locale" content="pt_BR">
-  <meta property="og:site_name" content="${SITE_NAME}">
+  <meta property="og:site_name" content="${SITE_NAME}">${articleTags}
 
-  <!-- Twitter -->
+  <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="${url}">
-  <meta name="twitter:title" content="${title}">
-  <meta name="twitter:description" content="${description}">
+  <meta name="twitter:title" content="${safeTitle}">
+  <meta name="twitter:description" content="${safeDescription}">
   <meta name="twitter:image" content="${image}">
 
   <!-- Theme color -->
@@ -101,10 +138,14 @@ function generateHtml({
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+
+  <!-- Canonical -->
+  <link rel="canonical" href="${url}">
 </head>
 <body>
-  <h1>${title}</h1>
-  <p>${description}</p>
+  <h1>${safeTitle}</h1>
+  <p>${safeDescription}</p>
+  <img src="${image}" alt="${safeTitle}">
   <p><a href="${url}">Acessar página</a></p>
 </body>
 </html>`
@@ -142,7 +183,7 @@ export default async function handler(request: Request): Promise<Response> {
       }
 
       const response = await fetch(
-        `${supabaseUrl}/rest/v1/eventos?id=eq.${eventId}&select=id,nome,descricao,imagem`,
+        `${supabaseUrl}/rest/v1/eventos?id=eq.${eventId}&select=id,nome,descricao,imagem,data_evento,horario,modalidade,cidade,estado,created_at`,
         {
           headers: {
             apikey: supabaseKey,
@@ -162,17 +203,34 @@ export default async function handler(request: Request): Promise<Response> {
         throw new Error('Event not found')
       }
 
-      const eventImage = event.imagem || `${origin}${DEFAULT_IMAGE}`
+      const eventImage = event.imagem || `${origin}${DEFAULT_IMAGE_PATH}`
       const absoluteImage = eventImage.startsWith('http')
         ? eventImage
         : `${origin}${eventImage.startsWith('/') ? '' : '/'}${eventImage}`
 
+      // Build a richer description with event details
+      const cleanDescription = truncateText(stripHtmlTags(event.descricao)) || ''
+      const details: string[] = []
+      if (event.data_evento) details.push(`Data: ${event.data_evento}`)
+      if (event.horario) details.push(`Horário: ${event.horario}`)
+      if (event.modalidade) details.push(event.modalidade)
+      if (event.cidade) {
+        const location = [event.cidade, event.estado].filter(Boolean).join(' - ')
+        details.push(location)
+      }
+
+      const detailsSuffix = details.length > 0 ? ` | ${details.join(' · ')}` : ''
+      const fullDescription = cleanDescription
+        ? truncateText(cleanDescription + detailsSuffix, 200)
+        : truncateText(details.join(' · ') || DEFAULT_DESCRIPTION, 200)
+
       const html = generateHtml({
         title: event.nome,
-        description: truncateText(stripHtmlTags(event.descricao)) || DEFAULT_DESCRIPTION,
+        description: fullDescription,
         image: absoluteImage,
         url: `${origin}/eventos/${event.id}`,
         type: 'article',
+        publishedTime: event.created_at,
       })
 
       return new Response(html, {
@@ -189,25 +247,24 @@ export default async function handler(request: Request): Promise<Response> {
 
   // Static pages with dynamic meta tags
   const pageSeo = PAGE_SEO[pathname]
-
-  if (pageSeo) {
-    const html = generateHtml({
-      title: pageSeo.title,
-      description: pageSeo.description,
-      image: `${origin}${DEFAULT_IMAGE}`,
-      url: `${origin}${pathname}`,
-      type: 'website',
-    })
-
-    return new Response(html, {
-      status: 200,
-      headers: {
-        'Content-Type': 'text/html; charset=utf-8',
-        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
-      },
-    })
+  const seoData = pageSeo || {
+    title: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
   }
 
-  // Fallback - redirect to SPA
-  return Response.redirect(`${origin}${pathname}`, 302)
+  const html = generateHtml({
+    title: seoData.title,
+    description: seoData.description,
+    image: `${origin}${DEFAULT_IMAGE_PATH}`,
+    url: `${origin}${pathname}`,
+    type: 'website',
+  })
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
 }

--- a/index.html
+++ b/index.html
@@ -12,7 +12,10 @@
     <meta property="og:url" content="https://eventos.cafebugado.com.br/" />
     <meta property="og:title" content="Eventos - Comunidade Cafe Bugado" />
     <meta property="og:description" content="Descubra os melhores eventos de tecnologia. Meetups, workshops, hackathons e conferencias reunidos em um so lugar pela comunidade." />
-    <meta property="og:image" content="/eventos.png" />
+    <meta property="og:image" content="https://eventos.cafebugado.com.br/eventos.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:locale" content="pt_BR" />
     <meta property="og:site_name" content="Eventos - Comunidade Cafe Bugado" />
 
@@ -21,7 +24,7 @@
     <meta name="twitter:url" content="https://eventos.cafebugado.com.br/" />
     <meta name="twitter:title" content="Eventos - Comunidade Cafe Bugado" />
     <meta name="twitter:description" content="Descubra os melhores eventos de tecnologia. Meetups, workshops, hackathons e conferencias reunidos em um so lugar pela comunidade." />
-    <meta name="twitter:image" content="/eventos.png" />
+    <meta name="twitter:image" content="https://eventos.cafebugado.com.br/eventos.png" />
 
     <!-- Theme color -->
     <meta name="theme-color" content="#2563eb" />

--- a/vercel.json
+++ b/vercel.json
@@ -1,59 +1,26 @@
 {
   "rewrites": [
     {
-      "source": "/",
-      "has": [
-        {
-          "type": "header",
-          "key": "user-agent",
-          "value": ".*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|WhatsApp|Slackbot|TelegramBot|Discordbot).*"
-        }
-      ],
-      "destination": "/api/og?path=/"
-    },
-    {
-      "source": "/eventos",
-      "has": [
-        {
-          "type": "header",
-          "key": "user-agent",
-          "value": ".*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|WhatsApp|Slackbot|TelegramBot|Discordbot).*"
-        }
-      ],
-      "destination": "/api/og?path=/eventos"
-    },
-    {
       "source": "/eventos/:id",
       "has": [
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|WhatsApp|Slackbot|TelegramBot|Discordbot).*"
+          "value": ".*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|WhatsApp|Slackbot|TelegramBot|Discordbot|Applebot|Pinterest|Googlebot|bingbot|Embedly|Quora Link Preview|Showyoubot|vkShare|Slack-ImgProxy|redditbot|Skype).*"
         }
       ],
       "destination": "/api/og?path=/eventos/:id"
     },
     {
-      "source": "/sobre",
+      "source": "/:path*",
       "has": [
         {
           "type": "header",
           "key": "user-agent",
-          "value": ".*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|WhatsApp|Slackbot|TelegramBot|Discordbot).*"
+          "value": ".*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|WhatsApp|Slackbot|TelegramBot|Discordbot|Applebot|Pinterest|Googlebot|bingbot|Embedly|Quora Link Preview|Showyoubot|vkShare|Slack-ImgProxy|redditbot|Skype).*"
         }
       ],
-      "destination": "/api/og?path=/sobre"
-    },
-    {
-      "source": "/contato",
-      "has": [
-        {
-          "type": "header",
-          "key": "user-agent",
-          "value": ".*(facebookexternalhit|Facebot|Twitterbot|LinkedInBot|WhatsApp|Slackbot|TelegramBot|Discordbot).*"
-        }
-      ],
-      "destination": "/api/og?path=/contato"
+      "destination": "/api/og?path=/:path*"
     },
     { "source": "/(.*)", "destination": "/" }
   ]


### PR DESCRIPTION
corrige o compartilhamento de links em redes sociais (whatsapp, facebook, twitter/x, linkedin, telegram, discord, etc.) para exibir título, descrição e imagem personalizados por página.

- corrige og:image e twitter:image no index.html para usar url absoluta
- adiciona og:image:width, og:image:height e og:image:type para melhor compatibilidade com crawlers
- amplia lista de crawlers detectados de 9 para 19 (googlebot, bingbot, reddit, skype, pinterest, vk, embedly, etc.)
- simplifica vercel.json com rota catch-all para interceptar crawlers em qualquer página automaticamente
- adiciona escapehtml para prevenir xss nas meta tags dinâmicas
- enriquece descrição de eventos com data, horário, modalidade e localização
- adiciona fallback universal para rotas desconhecidas em vez de redirect
- adiciona tag canonical e img no body para crawlers que analisam o html