### PR TITLE
feat(moderador): dashboard com stats clicaveis, perfil e back-button

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Uma plataforma moderna e minimalista da Comunidade Café Bugado para descobrir e
 - **Estatísticas** - Visualização de eventos por período
 - **Validação de Formulários** - React Hook Form com validações
 - **Controle de Acesso (RBAC)** - Permissões granulares por papel: super_admin, admin e moderador
+- **Perfil de Usuário** - Todos os papéis podem configurar nome, sobrenome e avatar via GitHub
+- **Dashboard do Moderador** - Stats clicáveis com visualização de contribuições, eventos da semana e próximos eventos
 
 ## Tecnologias Utilizadas
 
@@ -236,6 +238,7 @@ agendas_eventos/
 │   │   ├── eventService.js       # CRUD de eventos
 │   │   ├── eventService.test.js  # Testes de eventos
 │   │   ├── contributorService.js # CRUD de contribuintes
+│   │   ├── profileService.js     # Perfil do usuário (nome, sobrenome, avatar)
 │   │   └── tagService.js         # CRUD de tags e associação
 │   │
 │   ├── lib/                      # Configurações
@@ -338,13 +341,13 @@ CREATE TABLE evento_tags (
 | ----------------------- | ----------- | ----- | ------------------ |
 | Criar eventos           | ✅          | ✅    | ✅                 |
 | Editar eventos          | ✅          | ✅    | ✅                 |
-| Excluir eventos         | ✅          | ✅    | ❌                 |
+| Excluir eventos         | ✅          | ✅    | Apenas os próprios |
 | Criar tags              | ✅          | ✅    | ✅                 |
 | Editar tags             | ✅          | ✅    | Apenas as próprias |
 | Excluir tags            | ✅          | ✅    | Apenas as próprias |
 | Gerenciar contribuintes | ✅          | ✅    | ❌                 |
 | Gerenciar usuários      | ✅          | ❌    | ❌                 |
-| Upload de imagens       | ✅          | ✅    | ❌                 |
+| Upload de imagens       | ✅          | ✅    | ✅                 |
 
 ### Períodos Disponíveis
 

--- a/src/App.css
+++ b/src/App.css
@@ -58,27 +58,6 @@ body {
   padding: 0 2rem;
 }
 
-.back-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  padding: 0.625rem 1rem;
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.back-link:hover {
-  color: var(--primary-blue);
-  border-color: var(--primary-blue);
-  background: rgba(37, 99, 235, 0.05);
-}
-
 /* Header */
 .main-header {
   position: fixed;

--- a/src/admin/Admin.css
+++ b/src/admin/Admin.css
@@ -344,6 +344,133 @@
   color: #fca5a5;
 }
 
+/* User avatar image (GitHub) */
+.user-avatar-img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+/* Settings Section */
+.settings-section {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+}
+
+.settings-section .section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.settings-section .section-header h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.settings-avatar-area {
+  display: flex;
+  justify-content: center;
+  padding: 1rem 0 0.5rem;
+}
+
+.settings-avatar-preview {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid var(--border);
+}
+
+.settings-avatar-placeholder {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  background: var(--primary-blue);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 700;
+  border: 3px solid var(--border);
+}
+
+.settings-profile-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.settings-info-row {
+  display: flex;
+  align-items: center;
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid var(--border);
+  gap: 1rem;
+}
+
+.settings-info-row:last-child {
+  border-bottom: none;
+}
+
+.settings-info-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  min-width: 80px;
+}
+
+.settings-info-value {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.settings-info-empty {
+  color: var(--text-secondary);
+  font-style: italic;
+  font-weight: 400;
+}
+
+.settings-role-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--primary-blue);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: default;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+}
+
 /* Main Content */
 .admin-main {
   flex: 1;
@@ -376,6 +503,29 @@
   font-weight: 600;
   color: var(--text-primary);
   margin: 0;
+}
+
+.topbar-community-icon {
+  color: #e11d48;
+  flex-shrink: 0;
+}
+
+.topbar-greeting {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.topbar-greeting h1 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.topbar-greeting-sub {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
 }
 
 .topbar-right {
@@ -455,6 +605,11 @@
 .stat-icon.orange {
   background: rgba(249, 115, 22, 0.1);
   color: #f97316;
+}
+
+.stat-icon.purple {
+  background: rgba(139, 92, 246, 0.1);
+  color: #8b5cf6;
 }
 
 .stat-info {
@@ -853,7 +1008,8 @@
   grid-template-columns: 1fr 1fr;
 }
 
-.modal-form .form-field {
+.modal-form .form-field,
+.settings-form .form-field {
   flex: 1;
 }
 
@@ -868,7 +1024,9 @@
 }
 
 .modal-form input,
-.modal-form select {
+.modal-form select,
+.settings-form input,
+.settings-form select {
   width: 100%;
   padding: 0.75rem 1rem;
   border: 1px solid var(--border);
@@ -880,7 +1038,9 @@
 }
 
 .modal-form input:focus,
-.modal-form select:focus {
+.modal-form select:focus,
+.settings-form input:focus,
+.settings-form select:focus {
   outline: none;
   border-color: var(--primary-blue);
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
@@ -1690,4 +1850,83 @@
 /* User email cell */
 .user-email-cell {
   font-weight: 500;
+}
+
+/* ================================
+   Moderador - Sub-views
+   ================================ */
+
+.events-section .back-btn {
+  margin-bottom: 1.25rem;
+}
+
+/* Descrição truncada no card */
+.upcoming-card-desc {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-bottom: 0.25rem;
+}
+
+/* Badge encerrado */
+.upcoming-card-badge.badge-encerrado {
+  background: var(--text-secondary);
+}
+
+/* Botão saber mais */
+.participate-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  width: 100%;
+  background: var(--primary-blue);
+  color: white;
+  text-decoration: none;
+  padding: 1rem 2rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  font-size: 1rem;
+  transition: all 0.3s ease;
+  border: none;
+  cursor: pointer;
+}
+
+.participate-button:hover {
+  background: var(--dark-blue);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(37, 99, 235, 0.3);
+}
+
+.participate-button.disabled {
+  background: var(--text-secondary);
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* ================================
+   Moderador - Stat Cards Clicáveis
+   ================================ */
+
+.stat-card-clickable {
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.stat-card-clickable:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px var(--shadow);
+  border-color: var(--primary-blue);
+}
+
+.stat-card-clickable:active {
+  transform: translateY(-1px);
 }

--- a/src/components/BackButton.css
+++ b/src/components/BackButton.css
@@ -1,0 +1,21 @@
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  padding: 0.625rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-decoration: none;
+}
+
+.back-btn:hover {
+  color: var(--primary-blue);
+  border-color: var(--primary-blue);
+  background: rgba(37, 99, 235, 0.05);
+}

--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -1,0 +1,20 @@
+import { ArrowLeft } from 'lucide-react'
+import './BackButton.css'
+
+/**
+ * Botão de voltar reutilizável.
+ *
+ * Props:
+ *  - onClick: função chamada ao clicar (obrigatório)
+ *  - label: texto do botão (padrão: "Voltar")
+ */
+function BackButton({ onClick, label = 'Voltar' }) {
+  return (
+    <button className="back-btn" onClick={onClick}>
+      <ArrowLeft size={18} />
+      <span>{label}</span>
+    </button>
+  )
+}
+
+export default BackButton

--- a/src/hooks/useUserRole.js
+++ b/src/hooks/useUserRole.js
@@ -26,12 +26,12 @@ const PERMISSIONS = {
   moderador: {
     canCreateEvents: true,
     canEditEvents: true,
-    canDeleteEvents: false,
+    canDeleteEvents: true,
     canManageTags: true,
     canDeleteTags: true,
     canManageContributors: false,
     canManageUsers: false,
-    canUploadImages: false,
+    canUploadImages: true,
   },
 }
 

--- a/src/pages/About.css
+++ b/src/pages/About.css
@@ -12,27 +12,6 @@
   padding: 0 2rem;
 }
 
-.back-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  padding: 0.625rem 1rem;
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.back-link:hover {
-  color: var(--primary-blue);
-  border-color: var(--primary-blue);
-  background: rgba(37, 99, 235, 0.05);
-}
-
 /* Header */
 .main-header {
   position: fixed;

--- a/src/pages/Contact.css
+++ b/src/pages/Contact.css
@@ -12,27 +12,6 @@
   padding: 0 2rem;
 }
 
-.back-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  padding: 0.625rem 1rem;
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.back-link:hover {
-  color: var(--primary-blue);
-  border-color: var(--primary-blue);
-  background: rgba(37, 99, 235, 0.05);
-}
-
 /* Header */
 .main-header {
   position: fixed;

--- a/src/pages/EventDetails.css
+++ b/src/pages/EventDetails.css
@@ -127,26 +127,6 @@
   transform: translateY(0);
 }
 
-.back-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: transparent;
-  color: var(--text-primary);
-  border: 1px solid var(--border);
-  padding: 0.75rem 1.5rem;
-  border-radius: 0.5rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.back-button:hover {
-  border-color: var(--primary-blue);
-  color: var(--primary-blue);
-  background: rgba(37, 99, 235, 0.05);
-}
-
 /* Skeleton Loading for Details Page */
 .skeleton-back-button {
   width: 180px;
@@ -254,26 +234,8 @@
   padding: 2rem;
 }
 
-.details-container .back-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  padding: 0.625rem 1rem;
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
+.details-container .back-btn {
   margin-bottom: 2rem;
-}
-
-.details-container .back-link:hover {
-  color: var(--primary-blue);
-  border-color: var(--primary-blue);
-  background: rgba(37, 99, 235, 0.05);
 }
 
 /* Event Details Card */

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
-  ArrowLeft,
   Calendar,
   Clock,
   CalendarDays,
@@ -13,6 +12,7 @@ import {
 } from 'lucide-react'
 import { getEventById } from '../services/eventService'
 import { getEventTags } from '../services/tagService'
+import BackButton from '../components/BackButton'
 import Header from '../components/Header'
 import Footer from '../components/Footer'
 import FloatingMenu from '../components/FloatingMenu'
@@ -147,10 +147,7 @@ function EventDetails() {
         <Header />
         <main className="details-main">
           <div className="details-container">
-            <button onClick={() => navigate('/eventos')} className="back-link">
-              <ArrowLeft size={18} />
-              <span>Voltar para Eventos</span>
-            </button>
+            <BackButton onClick={() => navigate('/eventos')} label="Voltar para Eventos" />
             <div className="error-container" role="alert" aria-live="polite">
               <div className="error-icon">
                 <Calendar size={48} />
@@ -163,10 +160,7 @@ function EventDetails() {
                     Tentar novamente
                   </button>
                 )}
-                <button onClick={() => navigate('/eventos')} className="back-button">
-                  <ArrowLeft size={18} />
-                  Voltar para Eventos
-                </button>
+                <BackButton onClick={() => navigate('/eventos')} label="Voltar para Eventos" />
               </div>
             </div>
           </div>
@@ -197,10 +191,7 @@ function EventDetails() {
 
       <main className="details-main">
         <div className="details-container">
-          <button onClick={() => navigate('/eventos')} className="back-link">
-            <ArrowLeft size={18} />
-            <span>Voltar para Eventos</span>
-          </button>
+          <BackButton onClick={() => navigate('/eventos')} label="Voltar para Eventos" />
 
           <div className={`event-details-card ${isPast ? 'evento-encerrado' : ''}`}>
             <div className="event-image-container">

--- a/src/services/profileService.js
+++ b/src/services/profileService.js
@@ -1,0 +1,41 @@
+import { supabase } from '../lib/supabase'
+
+// Buscar perfil do usuario logado
+export async function getMyProfile() {
+  const { data, error } = await supabase.from('user_profiles').select('*').single()
+
+  if (error && error.code !== 'PGRST116') {
+    // PGRST116 = nenhuma linha encontrada (perfil ainda nao criado)
+    console.error('Erro ao buscar perfil:', error)
+    throw error
+  }
+
+  return data || null
+}
+
+// Criar ou atualizar perfil do usuario logado
+export async function upsertMyProfile({ nome, sobrenome, github_username, avatar_url }) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new Error('Usuário não autenticado')
+  }
+
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .upsert(
+      { user_id: user.id, nome, sobrenome, github_username, avatar_url },
+      { onConflict: 'user_id' }
+    )
+    .select()
+    .single()
+
+  if (error) {
+    console.error('Erro ao salvar perfil:', error)
+    throw error
+  }
+
+  return data
+}

--- a/src/test/utils.jsx
+++ b/src/test/utils.jsx
@@ -30,6 +30,7 @@ export function createMockEvent(overrides = {}) {
     link: 'https://evento.com',
     imagem: 'https://exemplo.com/imagem.jpg',
     created_at: '2024-01-01T00:00:00Z',
+    created_by: null,
     ...overrides,
   }
 }

--- a/supabase/migrations/008_moderador_permissions_update.sql
+++ b/supabase/migrations/008_moderador_permissions_update.sql
@@ -1,0 +1,91 @@
+-- =============================================
+-- MIGRATION: Atualizar permissoes do moderador
+-- - Moderador pode fazer upload de imagens
+-- - Moderador pode deletar apenas eventos que ele criou
+-- - Moderador pode editar qualquer evento (inclusive os que nao criou)
+-- =============================================
+
+-- =============================================
+-- 1. Adicionar coluna created_by na tabela eventos
+-- =============================================
+ALTER TABLE eventos ADD COLUMN IF NOT EXISTS created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+-- Indice para busca por criador
+CREATE INDEX IF NOT EXISTS idx_eventos_created_by ON eventos(created_by);
+
+-- =============================================
+-- 2. Trigger para preencher created_by automaticamente no INSERT
+-- =============================================
+CREATE OR REPLACE FUNCTION set_evento_created_by()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.created_by := auth.uid();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trigger_set_evento_created_by ON eventos;
+
+CREATE TRIGGER trigger_set_evento_created_by
+  BEFORE INSERT ON eventos
+  FOR EACH ROW
+  EXECUTE FUNCTION set_evento_created_by();
+
+-- =============================================
+-- 3. Atualizar politicas de DELETE da tabela eventos
+-- Moderador so pode deletar eventos que ele criou
+-- =============================================
+
+-- Remover politica antiga de delete
+DROP POLICY IF EXISTS "Admins podem deletar eventos" ON eventos;
+
+-- Admins deletam qualquer evento
+CREATE POLICY "Admins podem deletar eventos" ON eventos
+  FOR DELETE
+  USING (has_role(ARRAY['super_admin', 'admin']::app_role[]));
+
+-- Moderador so deleta os proprios eventos
+CREATE POLICY "Moderador pode deletar seus proprios eventos" ON eventos
+  FOR DELETE
+  USING (
+    has_role(ARRAY['moderador']::app_role[])
+    AND created_by = auth.uid()
+  );
+
+-- =============================================
+-- 4. Atualizar politicas de UPDATE da tabela eventos
+-- Moderador pode editar qualquer evento (inclusive os que nao criou)
+-- (a politica existente ja cobre isso, mas vamos garantir que esteja correta)
+-- =============================================
+
+-- Remover politica existente para recriar de forma explicita
+DROP POLICY IF EXISTS "Admins e moderadores podem atualizar eventos" ON eventos;
+
+-- Admins e moderadores podem atualizar qualquer evento
+CREATE POLICY "Admins e moderadores podem atualizar eventos" ON eventos
+  FOR UPDATE
+  USING (has_role(ARRAY['super_admin', 'admin', 'moderador']::app_role[]));
+
+-- =============================================
+-- 5. Atualizar politicas de STORAGE para permitir upload do moderador
+-- =============================================
+
+-- Remover politicas antigas de storage
+DROP POLICY IF EXISTS "Admins podem fazer upload" ON storage.objects;
+DROP POLICY IF EXISTS "Admins podem atualizar imagens" ON storage.objects;
+DROP POLICY IF EXISTS "Admins podem deletar imagens" ON storage.objects;
+
+-- Upload: admins e moderadores podem fazer upload
+CREATE POLICY "Admins e moderadores podem fazer upload" ON storage.objects
+  FOR INSERT
+  WITH CHECK (bucket_id = 'imagens' AND has_role(ARRAY['super_admin', 'admin', 'moderador']::app_role[]));
+
+-- Atualizar imagens: admins e moderadores
+CREATE POLICY "Admins e moderadores podem atualizar imagens" ON storage.objects
+  FOR UPDATE
+  USING (bucket_id = 'imagens' AND has_role(ARRAY['super_admin', 'admin', 'moderador']::app_role[]));
+
+-- Deletar imagens: apenas admins
+CREATE POLICY "Admins podem deletar imagens" ON storage.objects
+  FOR DELETE
+  USING (bucket_id = 'imagens' AND has_role(ARRAY['super_admin', 'admin']::app_role[]));

--- a/supabase/migrations/009_user_profiles.sql
+++ b/supabase/migrations/009_user_profiles.sql
@@ -1,0 +1,43 @@
+-- =============================================
+-- MIGRATION: Perfil de usuario
+-- Todos os perfis podem editar nome, sobrenome e github (avatar)
+-- =============================================
+
+-- 1. Criar tabela user_profiles
+CREATE TABLE IF NOT EXISTS user_profiles (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  nome TEXT,
+  sobrenome TEXT,
+  github_username TEXT,
+  avatar_url TEXT,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indice para busca rapida
+CREATE INDEX IF NOT EXISTS idx_user_profiles_user_id ON user_profiles(user_id);
+
+-- 2. RLS
+ALTER TABLE user_profiles ENABLE ROW LEVEL SECURITY;
+
+-- Cada usuario so ve o proprio perfil
+CREATE POLICY "Usuario pode ver seu proprio perfil"
+  ON user_profiles FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Cada usuario so insere o proprio perfil
+CREATE POLICY "Usuario pode criar seu proprio perfil"
+  ON user_profiles FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Cada usuario so edita o proprio perfil
+CREATE POLICY "Usuario pode atualizar seu proprio perfil"
+  ON user_profiles FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- 3. Trigger updated_at (reutiliza funcao da migration 001)
+DROP TRIGGER IF EXISTS update_user_profiles_updated_at ON user_profiles;
+
+CREATE TRIGGER update_user_profiles_updated_at
+  BEFORE UPDATE ON user_profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
- stats do moderador sao clicaveis e exibem sub-views com cards
- adiciona perfil de usuario com aba configuracoes para todos os papeis
- cria componente back-button reutilizavel e remove css duplicado
- moderador pode excluir apenas seus proprios eventos e fazer upload
- adiciona saudacao motivacional personalizada na topbar do moderador
- migrations: created_by em eventos (008) e tabela user_profiles (009)