### PR TITLE
Developer

### DIFF
--- a/src/admin/Admin.css
+++ b/src/admin/Admin.css
@@ -907,6 +907,16 @@
   background: rgba(239, 68, 68, 0.2);
 }
 
+.btn-delete-locked {
+  background: rgba(156, 163, 175, 0.1);
+  color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.btn-delete-locked:hover {
+  background: rgba(156, 163, 175, 0.15);
+}
+
 /* Past Events */
 .event-row-past {
   opacity: 0.6;

--- a/src/hooks/useUserRole.js
+++ b/src/hooks/useUserRole.js
@@ -20,7 +20,7 @@ const PERMISSIONS = {
     canManageTags: true,
     canDeleteTags: true,
     canManageContributors: true,
-    canManageUsers: false,
+    canManageUsers: true,
     canUploadImages: true,
   },
   moderador: {

--- a/src/services/roleService.js
+++ b/src/services/roleService.js
@@ -43,7 +43,20 @@ export async function getUsersWithRoles() {
   return data
 }
 
-// Atribuir role a um usuario (super_admin only)
+// Listar usuarios visiveis para admin: retorna apenas moderadores e usuarios sem role
+// Usa a RPC admin_get_users que valida permissoes no banco
+export async function getUsersWithRolesForAdmin() {
+  const { data, error } = await supabase.rpc('admin_get_users')
+
+  if (error) {
+    console.error('Erro ao listar usuarios (admin):', error)
+    throw error
+  }
+
+  return data || []
+}
+
+// Atribuir role a um usuario (super_admin only via assign_user_role)
 export async function assignUserRole(userId, role) {
   const { error } = await supabase.rpc('assign_user_role', {
     target_user_id: userId,
@@ -58,6 +71,21 @@ export async function assignUserRole(userId, role) {
   return true
 }
 
+// Atribuir role a um usuario (admin: so pode atribuir moderador)
+export async function adminAssignUserRole(userId, role) {
+  const { error } = await supabase.rpc('admin_assign_user_role', {
+    target_user_id: userId,
+    new_role: role,
+  })
+
+  if (error) {
+    console.error('Erro ao atribuir role (admin):', error)
+    throw error
+  }
+
+  return true
+}
+
 // Remover role de um usuario (super_admin only)
 export async function removeUserRole(userId) {
   const { error } = await supabase.rpc('remove_user_role', {
@@ -66,6 +94,20 @@ export async function removeUserRole(userId) {
 
   if (error) {
     console.error('Erro ao remover role:', error)
+    throw error
+  }
+
+  return true
+}
+
+// Remover role de um usuario (admin: so pode remover moderador)
+export async function adminRemoveUserRole(userId) {
+  const { error } = await supabase.rpc('admin_remove_user_role', {
+    target_user_id: userId,
+  })
+
+  if (error) {
+    console.error('Erro ao remover role (admin):', error)
     throw error
   }
 

--- a/supabase/migrations/010_admin_manage_users.sql
+++ b/supabase/migrations/010_admin_manage_users.sql
@@ -1,0 +1,120 @@
+-- =============================================
+-- MIGRATION: Admin pode gerenciar usuarios de nivel moderador e abaixo
+-- - admin pode listar usuarios (exceto super_admin e outros admins)
+-- - admin pode atribuir role 'moderador' a usuarios sem role
+-- - admin pode remover role de usuarios que sejam moderador
+-- =============================================
+
+-- =============================================
+-- 1. FUNCAO: admin_get_users
+-- Retorna usuarios com role <= moderador (exclui super_admin e admin)
+-- Acessivel por admin e super_admin
+-- =============================================
+CREATE OR REPLACE FUNCTION admin_get_users()
+RETURNS TABLE (
+  id UUID,
+  email TEXT,
+  created_at TIMESTAMP WITH TIME ZONE,
+  role app_role
+) AS $$
+BEGIN
+  IF NOT has_role(ARRAY['super_admin', 'admin']::app_role[]) THEN
+    RAISE EXCEPTION 'Acesso negado: apenas admin ou superior pode listar usuarios';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    u.id,
+    u.email::TEXT,
+    u.created_at,
+    ur.role
+  FROM auth.users u
+  LEFT JOIN user_roles ur ON u.id = ur.user_id
+  WHERE ur.role IS NULL OR ur.role IN ('moderador', 'admin')
+  ORDER BY u.created_at DESC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- =============================================
+-- 2. FUNCAO: admin_assign_user_role
+-- Admin pode atribuir apenas 'moderador' a usuarios sem role ou moderadores
+-- super_admin continua podendo usar assign_user_role para qualquer role
+-- =============================================
+CREATE OR REPLACE FUNCTION admin_assign_user_role(target_user_id UUID, new_role app_role)
+RETURNS void AS $$
+DECLARE
+  target_current_role app_role;
+BEGIN
+  IF NOT has_role(ARRAY['super_admin', 'admin']::app_role[]) THEN
+    RAISE EXCEPTION 'Acesso negado';
+  END IF;
+
+  IF target_user_id = auth.uid() THEN
+    RAISE EXCEPTION 'Voce nao pode alterar sua propria role';
+  END IF;
+
+  -- Se for admin (nao super_admin), restricoes adicionais
+  IF has_role(ARRAY['admin']::app_role[]) AND NOT has_role(ARRAY['super_admin']::app_role[]) THEN
+    -- Admin so pode atribuir moderador
+    IF new_role != 'moderador' THEN
+      RAISE EXCEPTION 'Admin so pode atribuir a role moderador';
+    END IF;
+
+    -- Verificar se o alvo e super_admin ou admin (nao pode tocar)
+    SELECT ur.role INTO target_current_role
+    FROM user_roles ur
+    WHERE ur.user_id = target_user_id;
+
+    IF target_current_role IN ('super_admin', 'admin') THEN
+      RAISE EXCEPTION 'Admin nao pode alterar a role de outro admin ou superior';
+    END IF;
+  END IF;
+
+  INSERT INTO user_roles (user_id, role)
+  VALUES (target_user_id, new_role)
+  ON CONFLICT (user_id)
+  DO UPDATE SET role = new_role, updated_at = NOW();
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- =============================================
+-- 3. FUNCAO: admin_remove_user_role
+-- Admin pode remover role apenas de moderadores
+-- super_admin continua podendo usar remove_user_role para qualquer um
+-- =============================================
+CREATE OR REPLACE FUNCTION admin_remove_user_role(target_user_id UUID)
+RETURNS void AS $$
+DECLARE
+  target_current_role app_role;
+BEGIN
+  IF NOT has_role(ARRAY['super_admin', 'admin']::app_role[]) THEN
+    RAISE EXCEPTION 'Acesso negado';
+  END IF;
+
+  IF target_user_id = auth.uid() THEN
+    RAISE EXCEPTION 'Voce nao pode remover sua propria role';
+  END IF;
+
+  -- Se for admin (nao super_admin), restricoes adicionais
+  IF has_role(ARRAY['admin']::app_role[]) AND NOT has_role(ARRAY['super_admin']::app_role[]) THEN
+    SELECT ur.role INTO target_current_role
+    FROM user_roles ur
+    WHERE ur.user_id = target_user_id;
+
+    IF target_current_role IN ('super_admin', 'admin') THEN
+      RAISE EXCEPTION 'Admin nao pode remover a role de outro admin ou superior';
+    END IF;
+  END IF;
+
+  DELETE FROM user_roles WHERE user_id = target_user_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- =============================================
+-- MIGRATION COMPLETA!
+--
+-- Novas funcoes:
+-- - admin_get_users(): lista usuarios moderador/sem role (admin+)
+-- - admin_assign_user_role(): atribui role com restricoes para admin
+-- - admin_remove_user_role(): remove role com restricoes para admin
+-- =============================================

--- a/supabase/migrations/011_users_with_profiles.sql
+++ b/supabase/migrations/011_users_with_profiles.sql
@@ -1,0 +1,95 @@
+-- =============================================
+-- MIGRATION: Incluir nome e sobrenome nas listagens de usuarios
+-- Atualiza get_users_with_roles e admin_get_users para fazer JOIN com user_profiles
+-- =============================================
+
+-- =============================================
+-- 1. Politica de leitura de perfis para admin+
+-- Necessaria para o JOIN funcionar no SECURITY DEFINER
+-- (funcoes SECURITY DEFINER ja tem acesso, mas adicionamos para clareza)
+-- =============================================
+
+-- Adiciona policy para super_admin e admin lerem todos os perfis
+DROP POLICY IF EXISTS "Admin pode ver todos os perfis" ON user_profiles;
+
+CREATE POLICY "Admin pode ver todos os perfis"
+  ON user_profiles FOR SELECT
+  USING (has_role(ARRAY['super_admin', 'admin']::app_role[]));
+
+-- =============================================
+-- 2. Atualizar get_users_with_roles (super_admin)
+-- Inclui nome e sobrenome do user_profiles
+-- =============================================
+DROP FUNCTION IF EXISTS get_users_with_roles();
+CREATE OR REPLACE FUNCTION get_users_with_roles()
+RETURNS TABLE (
+  id UUID,
+  email TEXT,
+  nome TEXT,
+  sobrenome TEXT,
+  created_at TIMESTAMP WITH TIME ZONE,
+  role app_role
+) AS $$
+BEGIN
+  IF NOT has_role(ARRAY['super_admin']::app_role[]) THEN
+    RAISE EXCEPTION 'Acesso negado: apenas super_admin pode listar usuarios';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    u.id,
+    u.email::TEXT,
+    p.nome,
+    p.sobrenome,
+    u.created_at,
+    ur.role
+  FROM auth.users u
+  LEFT JOIN user_roles ur ON u.id = ur.user_id
+  LEFT JOIN user_profiles p ON u.id = p.user_id
+  ORDER BY u.email ASC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- =============================================
+-- 3. Atualizar admin_get_users (admin+)
+-- Inclui nome e sobrenome do user_profiles
+-- =============================================
+DROP FUNCTION IF EXISTS admin_get_users();
+CREATE OR REPLACE FUNCTION admin_get_users()
+RETURNS TABLE (
+  id UUID,
+  email TEXT,
+  nome TEXT,
+  sobrenome TEXT,
+  created_at TIMESTAMP WITH TIME ZONE,
+  role app_role
+) AS $$
+BEGIN
+  IF NOT has_role(ARRAY['super_admin', 'admin']::app_role[]) THEN
+    RAISE EXCEPTION 'Acesso negado: apenas admin ou superior pode listar usuarios';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    u.id,
+    u.email::TEXT,
+    p.nome,
+    p.sobrenome,
+    u.created_at,
+    ur.role
+  FROM auth.users u
+  LEFT JOIN user_roles ur ON u.id = ur.user_id
+  LEFT JOIN user_profiles p ON u.id = p.user_id
+  WHERE ur.role IS NULL OR ur.role IN ('moderador', 'admin')
+  ORDER BY u.email ASC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- =============================================
+-- MIGRATION COMPLETA!
+--
+-- Alteracoes:
+-- - get_users_with_roles(): agora retorna nome e sobrenome
+-- - admin_get_users(): agora retorna nome e sobrenome
+-- - Nova policy: admin pode ler todos os perfis
+-- =============================================


### PR DESCRIPTION
- admin visualiza usuários com roles moderador e admin (exceto super_admin)
- admin pode atribuir e remover role de moderadores
- admin não pode alterar ou remover roles de outros admins
- select e lixeira desabilitados com visual cinza para roles protegidas
- lista ordenada alfabeticamente com usuário logado sempre em primeiro
- coluna exibe nome e sobrenome do perfil, com fallback para email
- novas migrations: RPCs admin_get_users, admin_assign_user_role, admin_remove_user_role
- migration 011 inclui nome/sobrenome via JOIN com user_profiles