### PR TITLE
Developer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,21 @@ VITE_SUPABASE_ANON_KEY=sua-anon-key-aqui
 # VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 
 # ===========================================
+# GITHUB (Dashboard Admin - Dados do Repositório)
+# ===========================================
+# Token pessoal do GitHub para exibir dados do repositório no dashboard.
+# Crie em: https://github.com/settings/tokens (escopo: public_repo)
+# Sem token: limite de 60 req/hora (API pública)
+# Com token: limite de 5000 req/hora
+# VITE_GITHUB_TOKEN=ghp_seu_token_aqui
+#
+# Repositório frontend (padrão: cafebugado/agendas_eventos)
+# VITE_GITHUB_REPO=cafebugado/agendas_eventos
+#
+# Repositório backend
+# VITE_GITHUB_REPO_BACKEND=cafebugado/backendEventos
+
+# ===========================================
 # DOCKER
 # ===========================================
 # As variáveis acima são automaticamente

--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -37,6 +37,7 @@ import {
   UserCog,
   Settings,
   Heart,
+  GitBranch,
 } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import { getSession, signOut, getCurrentUser } from '../services/authService'
@@ -86,6 +87,7 @@ import './Admin.css'
 import '../components/UpcomingEvents.css'
 import BackButton from '../components/BackButton'
 import EventCard from '../components/EventCard'
+import GithubStats from './GithubStats'
 import BgEventos from '../assets/eventos.png'
 
 const DAY_NAMES = [
@@ -1033,6 +1035,15 @@ function Dashboard() {
               <span>Contribuintes</span>
             </button>
           )}
+          {permissions.canManageContributors && (
+            <button
+              className={`menu-item ${activeTab === 'repositorio' ? 'active' : ''}`}
+              onClick={() => setActiveTab('repositorio')}
+            >
+              <GitBranch size={20} />
+              <span>Repositório</span>
+            </button>
+          )}
           {permissions.canManageUsers && (
             <button
               className={`menu-item ${activeTab === 'usuarios' ? 'active' : ''}`}
@@ -1132,7 +1143,8 @@ function Dashboard() {
               {activeTab !== 'contribuintes' &&
                 activeTab !== 'tags' &&
                 activeTab !== 'usuarios' &&
-                activeTab !== 'configuracoes' && (
+                activeTab !== 'configuracoes' &&
+                activeTab !== 'repositorio' && (
                   <>
                     {/* Stats */}
                     <div className="stats-grid">
@@ -1843,6 +1855,13 @@ function Dashboard() {
                       ))}
                     </div>
                   )}
+                </div>
+              )}
+
+              {/* Repositório GitHub Section */}
+              {activeTab === 'repositorio' && permissions.canManageContributors && (
+                <div className="events-section">
+                  <GithubStats />
                 </div>
               )}
 

--- a/src/admin/GithubStats.css
+++ b/src/admin/GithubStats.css
@@ -1,0 +1,455 @@
+/* ================================
+   GitHub Stats Panel
+   ================================ */
+
+.gh-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* Header */
+.gh-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.gh-header-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-primary);
+}
+
+.gh-header-title h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.gh-header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Abas de repositório */
+.gh-repo-tabs {
+  display: flex;
+  gap: 0.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 0.2rem;
+}
+
+.gh-repo-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: transparent;
+  border: none;
+  border-radius: 0.35rem;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  font-weight: 500;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.gh-repo-tab:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+.gh-repo-tab--active {
+  background: var(--primary-blue);
+  color: #fff;
+}
+
+.gh-repo-tab--active:hover {
+  background: var(--primary-blue);
+  color: #fff;
+  opacity: 0.9;
+}
+
+/* Link do repo na stats bar */
+.gh-repo-link {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: var(--primary-blue);
+  text-decoration: none;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.gh-repo-link:hover {
+  text-decoration: underline;
+}
+
+.gh-stats-bar-divider {
+  width: 1px;
+  height: 16px;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+.gh-stats-bar-refresh {
+  margin-left: auto;
+}
+
+/* Refresh button */
+.gh-refresh-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.gh-refresh-btn:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+.gh-refresh-btn--icon {
+  padding: 0.35rem 0.45rem;
+}
+
+/* Stats bar */
+.gh-stats-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.gh-stat {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.gh-stat strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.gh-stat--lang {
+  color: var(--text-secondary);
+}
+
+.gh-lang-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--primary-blue);
+  flex-shrink: 0;
+}
+
+.gh-stat--updated {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+/* Grid */
+.gh-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.gh-card--wide {
+  grid-column: 1 / -1;
+}
+
+/* Card */
+.gh-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.gh-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Lists */
+.gh-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.gh-list-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+
+.gh-list-item--skeleton {
+  align-items: center;
+}
+
+.gh-list-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.gh-commit-msg {
+  font-size: 0.82rem;
+  color: var(--text-primary);
+  text-decoration: none;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.gh-commit-msg:hover {
+  color: var(--primary-blue);
+  text-decoration: underline;
+}
+
+.gh-meta {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.1rem;
+}
+
+.gh-sha {
+  font-family: monospace;
+  font-size: 0.72rem;
+  background: var(--border);
+  padding: 0 0.3rem;
+  border-radius: 3px;
+  color: var(--text-secondary);
+}
+
+.gh-pr-number {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+}
+
+/* PR badges */
+.gh-pr-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  border-radius: 10px;
+}
+
+.gh-pr-badge--open {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.gh-pr-badge--merged {
+  background: #ede9fe;
+  color: #7c3aed;
+}
+
+.gh-pr-badge--closed {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+/* Avatares */
+.gh-avatar {
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.gh-avatar--sm {
+  width: 28px;
+  height: 28px;
+}
+
+.gh-avatar--md {
+  width: 40px;
+  height: 40px;
+}
+
+.gh-avatar--placeholder {
+  background: var(--border);
+}
+
+/* Contributors */
+.gh-contributors-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.gh-contributor {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.gh-contributor--skeleton {
+  align-items: center;
+}
+
+.gh-contributor-rank {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  width: 22px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.gh-contributor-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.gh-contributor-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.gh-contributor-name:hover {
+  color: var(--primary-blue);
+  text-decoration: underline;
+}
+
+.gh-contributor-commits {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.2rem 0.6rem;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Skeleton */
+.gh-skeleton {
+  background: linear-gradient(90deg, var(--border) 25%, var(--surface) 50%, var(--border) 75%);
+  background-size: 200% 100%;
+  animation: gh-shimmer 1.4s infinite;
+  border-radius: 4px;
+}
+
+@keyframes gh-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Error state */
+.gh-error {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #dc2626;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  font-size: 0.875rem;
+}
+
+.gh-error .gh-refresh-btn {
+  margin-left: auto;
+}
+
+/* Dark mode overrides */
+.dark .gh-pr-badge--open {
+  background: #14532d;
+  color: #86efac;
+}
+
+.dark .gh-pr-badge--merged {
+  background: #2e1065;
+  color: #c4b5fd;
+}
+
+.dark .gh-pr-badge--closed {
+  background: #450a0a;
+  color: #fca5a5;
+}
+
+.dark .gh-error {
+  background: #450a0a;
+  border-color: #7f1d1d;
+  color: #fca5a5;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .gh-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gh-card--wide {
+    grid-column: 1;
+  }
+
+  .gh-stat--updated {
+    margin-left: 0;
+    width: 100%;
+  }
+}

--- a/src/admin/GithubStats.jsx
+++ b/src/admin/GithubStats.jsx
@@ -1,0 +1,398 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  GitBranch,
+  Star,
+  GitFork,
+  AlertCircle,
+  GitCommitHorizontal,
+  GitPullRequest,
+  Users,
+  ExternalLink,
+  RefreshCw,
+  CircleDot,
+  GitMerge,
+  XCircle,
+  Monitor,
+  Server,
+} from 'lucide-react'
+import {
+  getRepoStats,
+  getRecentCommits,
+  getRecentPRs,
+  getTopContributors,
+} from '../services/githubService'
+import './GithubStats.css'
+
+const REPOS = [
+  {
+    id: 'frontend',
+    label: 'Frontend',
+    repo: import.meta.env.VITE_GITHUB_REPO || 'cafebugado/agendas_eventos',
+    icon: Monitor,
+  },
+  {
+    id: 'backend',
+    label: 'Backend',
+    repo: import.meta.env.VITE_GITHUB_REPO_BACKEND || 'cafebugado/backendEventos',
+    icon: Server,
+  },
+]
+
+function formatRelativeDate(dateStr) {
+  if (!dateStr) {
+    return ''
+  }
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 60) {
+    return `${minutes}min atrás`
+  }
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `${hours}h atrás`
+  }
+  const days = Math.floor(hours / 24)
+  if (days < 30) {
+    return `${days}d atrás`
+  }
+  const months = Math.floor(days / 30)
+  return `${months}m atrás`
+}
+
+function PRBadge({ state }) {
+  if (state === 'merged') {
+    return (
+      <span className="gh-pr-badge gh-pr-badge--merged">
+        <GitMerge size={12} /> merged
+      </span>
+    )
+  }
+  if (state === 'open') {
+    return (
+      <span className="gh-pr-badge gh-pr-badge--open">
+        <CircleDot size={12} /> open
+      </span>
+    )
+  }
+  return (
+    <span className="gh-pr-badge gh-pr-badge--closed">
+      <XCircle size={12} /> closed
+    </span>
+  )
+}
+
+function Skeleton({ width = '100%', height = 16, style = {} }) {
+  return <div className="gh-skeleton" style={{ width, height, ...style }} />
+}
+
+const stopProp = (e) => e.stopPropagation()
+
+function RepoPanel({ repo }) {
+  const [repoStats, setRepoStats] = useState(null)
+  const [commits, setCommits] = useState([])
+  const [prs, setPrs] = useState([])
+  const [contributors, setContributors] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const loadAll = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [stats, recentCommits, recentPRs, topContributors] = await Promise.all([
+        getRepoStats(repo),
+        getRecentCommits(5, repo),
+        getRecentPRs(5, repo),
+        getTopContributors(5, repo),
+      ])
+      setRepoStats(stats)
+      setCommits(recentCommits)
+      setPrs(recentPRs)
+      setContributors(topContributors)
+    } catch (err) {
+      setError(err.message || 'Erro ao carregar dados do GitHub')
+    } finally {
+      setLoading(false)
+    }
+  }, [repo])
+
+  useEffect(() => {
+    loadAll()
+  }, [loadAll])
+
+  if (error) {
+    return (
+      <div className="gh-error">
+        <AlertCircle size={20} />
+        <span>{error}</span>
+        <button type="button" className="gh-refresh-btn" onClick={loadAll}>
+          <RefreshCw size={16} /> Tentar novamente
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {/* Stats bar */}
+      <div className="gh-stats-bar">
+        {loading ? (
+          <>
+            <Skeleton width={80} />
+            <Skeleton width={80} />
+            <Skeleton width={80} />
+            <Skeleton width={120} />
+          </>
+        ) : repoStats ? (
+          <>
+            <a
+              href={repoStats.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="gh-repo-link"
+              onClick={stopProp}
+            >
+              {repo} <ExternalLink size={13} />
+            </a>
+            <span className="gh-stats-bar-divider" />
+            <span className="gh-stat">
+              <Star size={15} />
+              <strong>{repoStats.stars}</strong> stars
+            </span>
+            <span className="gh-stat">
+              <GitFork size={15} />
+              <strong>{repoStats.forks}</strong> forks
+            </span>
+            <span className="gh-stat">
+              <AlertCircle size={15} />
+              <strong>{repoStats.open_issues}</strong> issues abertas
+            </span>
+            {repoStats.language && (
+              <span className="gh-stat gh-stat--lang">
+                <span className="gh-lang-dot" />
+                {repoStats.language}
+              </span>
+            )}
+            <span className="gh-stat gh-stat--updated">
+              Atualizado {formatRelativeDate(repoStats.updated_at)}
+            </span>
+            <button
+              type="button"
+              className="gh-refresh-btn gh-refresh-btn--icon gh-stats-bar-refresh"
+              onClick={loadAll}
+              title="Atualizar"
+            >
+              <RefreshCw size={15} />
+            </button>
+          </>
+        ) : null}
+      </div>
+
+      {/* Grid principal */}
+      <div className="gh-grid">
+        {/* Commits recentes */}
+        <div className="gh-card">
+          <div className="gh-card-header">
+            <GitCommitHorizontal size={16} />
+            <span>Commits recentes</span>
+          </div>
+          <ul className="gh-list">
+            {loading
+              ? Array.from({ length: 5 }).map((_, i) => (
+                  <li key={i} className="gh-list-item gh-list-item--skeleton">
+                    <Skeleton
+                      width={32}
+                      height={32}
+                      style={{ borderRadius: '50%', flexShrink: 0 }}
+                    />
+                    <div style={{ flex: 1 }}>
+                      <Skeleton width="80%" height={14} />
+                      <Skeleton width="50%" height={12} style={{ marginTop: 4 }} />
+                    </div>
+                  </li>
+                ))
+              : commits.map((commit) => (
+                  <li key={commit.sha} className="gh-list-item">
+                    {commit.author_avatar ? (
+                      <img
+                        src={commit.author_avatar}
+                        alt={commit.author_login || commit.author_name}
+                        className="gh-avatar gh-avatar--sm"
+                      />
+                    ) : (
+                      <div className="gh-avatar gh-avatar--sm gh-avatar--placeholder" />
+                    )}
+                    <div className="gh-list-item-body">
+                      <a
+                        href={commit.html_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="gh-commit-msg"
+                        title={commit.message}
+                        onClick={stopProp}
+                      >
+                        {commit.message.length > 60
+                          ? commit.message.slice(0, 60) + '…'
+                          : commit.message}
+                      </a>
+                      <span className="gh-meta">
+                        <code className="gh-sha">{commit.short_sha}</code>
+                        &nbsp;·&nbsp;
+                        {commit.author_login ? `@${commit.author_login}` : commit.author_name}
+                        &nbsp;·&nbsp;
+                        {formatRelativeDate(commit.date)}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+          </ul>
+        </div>
+
+        {/* Pull Requests */}
+        <div className="gh-card">
+          <div className="gh-card-header">
+            <GitPullRequest size={16} />
+            <span>Pull Requests recentes</span>
+          </div>
+          <ul className="gh-list">
+            {loading
+              ? Array.from({ length: 5 }).map((_, i) => (
+                  <li key={i} className="gh-list-item gh-list-item--skeleton">
+                    <Skeleton
+                      width={32}
+                      height={32}
+                      style={{ borderRadius: '50%', flexShrink: 0 }}
+                    />
+                    <div style={{ flex: 1 }}>
+                      <Skeleton width="80%" height={14} />
+                      <Skeleton width="50%" height={12} style={{ marginTop: 4 }} />
+                    </div>
+                  </li>
+                ))
+              : prs.map((pr) => (
+                  <li key={pr.number} className="gh-list-item">
+                    {pr.author_avatar ? (
+                      <img
+                        src={pr.author_avatar}
+                        alt={pr.author_login}
+                        className="gh-avatar gh-avatar--sm"
+                      />
+                    ) : (
+                      <div className="gh-avatar gh-avatar--sm gh-avatar--placeholder" />
+                    )}
+                    <div className="gh-list-item-body">
+                      <a
+                        href={pr.html_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="gh-commit-msg"
+                        title={pr.title}
+                        onClick={stopProp}
+                      >
+                        <span className="gh-pr-number">#{pr.number}</span>{' '}
+                        {pr.title.length > 55 ? pr.title.slice(0, 55) + '…' : pr.title}
+                      </a>
+                      <span className="gh-meta">
+                        <PRBadge state={pr.state} />
+                        &nbsp;·&nbsp;
+                        {pr.author_login ? `@${pr.author_login}` : ''}
+                        &nbsp;·&nbsp;
+                        {formatRelativeDate(pr.updated_at)}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+          </ul>
+        </div>
+
+        {/* Top Contributors */}
+        <div className="gh-card gh-card--wide">
+          <div className="gh-card-header">
+            <Users size={16} />
+            <span>Top contribuidores</span>
+          </div>
+          <ul className="gh-contributors-list">
+            {loading
+              ? Array.from({ length: 5 }).map((_, i) => (
+                  <li key={i} className="gh-contributor gh-contributor--skeleton">
+                    <Skeleton
+                      width={40}
+                      height={40}
+                      style={{ borderRadius: '50%', flexShrink: 0 }}
+                    />
+                    <div style={{ flex: 1 }}>
+                      <Skeleton width="60%" height={14} />
+                    </div>
+                    <Skeleton width={80} height={24} style={{ borderRadius: 12 }} />
+                  </li>
+                ))
+              : contributors.map((c, i) => (
+                  <li key={c.login} className="gh-contributor">
+                    <span className="gh-contributor-rank">#{i + 1}</span>
+                    <a
+                      href={c.html_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={stopProp}
+                    >
+                      <img src={c.avatar_url} alt={c.login} className="gh-avatar gh-avatar--md" />
+                    </a>
+                    <div className="gh-contributor-info">
+                      <a
+                        href={c.html_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="gh-contributor-name"
+                        onClick={stopProp}
+                      >
+                        @{c.login}
+                      </a>
+                    </div>
+                    <span className="gh-contributor-commits">
+                      <GitCommitHorizontal size={14} />
+                      {c.contributions} commits
+                    </span>
+                  </li>
+                ))}
+          </ul>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default function GithubStats() {
+  const [activeRepo, setActiveRepo] = useState(REPOS[0].id)
+  const current = REPOS.find((r) => r.id === activeRepo)
+
+  return (
+    <div className="gh-panel">
+      {/* Header */}
+      <div className="gh-header">
+        <div className="gh-header-title">
+          <GitBranch size={20} />
+          <h2>Repositórios GitHub</h2>
+        </div>
+        {/* Abas internas */}
+        <div className="gh-repo-tabs">
+          {REPOS.map((r) => {
+            const Icon = r.icon
+            return (
+              <button
+                key={r.id}
+                type="button"
+                className={`gh-repo-tab ${activeRepo === r.id ? 'gh-repo-tab--active' : ''}`}
+                onClick={() => setActiveRepo(r.id)}
+              >
+                <Icon size={15} />
+                {r.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <RepoPanel key={current.repo} repo={current.repo} />
+    </div>
+  )
+}

--- a/src/services/githubService.js
+++ b/src/services/githubService.js
@@ -1,0 +1,103 @@
+const DEFAULT_REPO = import.meta.env.VITE_GITHUB_REPO || 'cafebugado/agendas_eventos'
+const TOKEN = import.meta.env.VITE_GITHUB_TOKEN
+
+function ghHeaders() {
+  const headers = { Accept: 'application/vnd.github+json' }
+  if (TOKEN) {
+    headers['Authorization'] = `Bearer ${TOKEN}`
+  }
+  return headers
+}
+
+// Cache simples em memória: { key -> { data, expiresAt } }
+const cache = {}
+const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutos
+
+async function ghFetch(path, repo) {
+  const cacheKey = path
+  const now = Date.now()
+
+  if (cache[cacheKey] && cache[cacheKey].expiresAt > now) {
+    return cache[cacheKey].data
+  }
+
+  const response = await fetch(`https://api.github.com${path}`, { headers: ghHeaders() })
+
+  if (!response.ok) {
+    if (response.status === 403) {
+      throw new Error(
+        'Limite de requisições da API do GitHub atingido. Configure VITE_GITHUB_TOKEN.'
+      )
+    }
+    if (response.status === 404) {
+      throw new Error(`Repositório "${repo}" não encontrado.`)
+    }
+    throw new Error(`Erro ao acessar GitHub API: ${response.status}`)
+  }
+
+  const data = await response.json()
+  cache[cacheKey] = { data, expiresAt: now + CACHE_TTL_MS }
+  return data
+}
+
+// Estatísticas gerais do repositório
+export async function getRepoStats(repo = DEFAULT_REPO) {
+  const data = await ghFetch(`/repos/${repo}`, repo)
+  return {
+    name: data.name,
+    full_name: data.full_name,
+    description: data.description,
+    stars: data.stargazers_count,
+    forks: data.forks_count,
+    open_issues: data.open_issues_count,
+    language: data.language,
+    html_url: data.html_url,
+    updated_at: data.updated_at,
+    default_branch: data.default_branch,
+  }
+}
+
+// Commits recentes
+export async function getRecentCommits(n = 5, repo = DEFAULT_REPO) {
+  const data = await ghFetch(`/repos/${repo}/commits?per_page=${n}`, repo)
+  return data.map((item) => ({
+    sha: item.sha,
+    short_sha: item.sha.slice(0, 7),
+    message: item.commit.message.split('\n')[0],
+    author_name: item.commit.author?.name || item.author?.login || 'Desconhecido',
+    author_login: item.author?.login || null,
+    author_avatar: item.author?.avatar_url || null,
+    date: item.commit.author?.date || null,
+    html_url: item.html_url,
+  }))
+}
+
+// Pull Requests recentes (abertos + fechados/mergeados)
+export async function getRecentPRs(n = 5, repo = DEFAULT_REPO) {
+  const data = await ghFetch(
+    `/repos/${repo}/pulls?state=all&per_page=${n}&sort=updated&direction=desc`,
+    repo
+  )
+  return data.map((pr) => ({
+    number: pr.number,
+    title: pr.title,
+    state: pr.merged_at ? 'merged' : pr.state,
+    author_login: pr.user?.login || null,
+    author_avatar: pr.user?.avatar_url || null,
+    html_url: pr.html_url,
+    created_at: pr.created_at,
+    updated_at: pr.updated_at,
+    merged_at: pr.merged_at,
+  }))
+}
+
+// Top contributors por número de commits
+export async function getTopContributors(n = 5, repo = DEFAULT_REPO) {
+  const data = await ghFetch(`/repos/${repo}/contributors?per_page=${n}`, repo)
+  return data.map((c) => ({
+    login: c.login,
+    avatar_url: c.avatar_url,
+    html_url: c.html_url,
+    contributions: c.contributions,
+  }))
+}


### PR DESCRIPTION
## Summary

- Adiciona aba **Repositório** no sidebar do Dashboard (visível para `admin` e `super_admin`)
- Exibe dados em tempo real dos repositórios frontend e backend via GitHub REST API v3
- Painel com abas internas **Frontend** / **Backend** para alternar entre os repos

## O que é exibido

- **Estatísticas do repo**: stars, forks, issues abertas, linguagem, última atualização
- **Commits recentes**: últimos 5 commits com autor, sha, mensagem e data relativa
- **Pull Requests recentes**: últimos 5 PRs com status (open/merged/closed), autor e data
- **Top contribuidores**: top 5 por número de commits com avatar e total

## Arquivos criados

- `src/services/githubService.js` — funções de API com cache de 5 min em memória
- `src/admin/GithubStats.jsx` — componente com loading skeleton e estado de erro
- `src/admin/GithubStats.css` — estilos com variáveis CSS do projeto e suporte a dark mode

## Arquivos modificados

- `src/admin/Dashboard.jsx` — nova aba Repositório no sidebar
- `.env.example` — documentação de `VITE_GITHUB_TOKEN`, `VITE_GITHUB_REPO` e `VITE_GITHUB_REPO_BACKEND`

## Test plan

- [x] Logar como `admin` ou `super_admin` e verificar aba **Repositório** no sidebar
- [x] Verificar carregamento dos dados de ambos os repos (Frontend/Backend)
- [x] Clicar em links de commits, PRs e contributors — deve abrir nova aba sem recarregar o dashboard
- [x] Verificar que `moderador` **não vê** a aba Repositório
- [x] Testar botão de atualizar (ícone refresh na stats bar)
- [x] Testar sem `VITE_GITHUB_TOKEN` — deve exibir mensagem de erro amigável
