### PR TITLE
feat(dashboard): melhorias na gestão de eventos e tags

### DIFF
--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -324,26 +324,7 @@ function Dashboard() {
   } = useForm()
 
   const sortedEvents = useMemo(() => {
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-
-    return [...eventos].sort((a, b) => {
-      const dateA = parseDateValue(a.data_evento)
-      const dateB = parseDateValue(b.data_evento)
-      const isAFuture = dateA && dateA >= today
-      const isBFuture = dateB && dateB >= today
-
-      if (isAFuture && !isBFuture) {
-        return -1
-      }
-      if (!isAFuture && isBFuture) {
-        return 1
-      }
-      if (isAFuture) {
-        return dateA - dateB
-      }
-      return dateB - dateA
-    })
+    return [...eventos].sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
   }, [eventos])
 
   const filteredEvents = useMemo(
@@ -531,6 +512,15 @@ function Dashboard() {
   }
 
   const onSubmit = async (data) => {
+    const nomeNorm = data.nome.trim().toLowerCase()
+    const duplicateEvent = eventos.find(
+      (e) => e.nome.trim().toLowerCase() === nomeNorm && (!editingEvent || e.id !== editingEvent.id)
+    )
+    if (duplicateEvent) {
+      showNotification('Já existe um evento com esse nome.', 'error')
+      return
+    }
+
     setIsSubmitting(true)
     try {
       let imageUrl = data.imagem || null
@@ -844,6 +834,15 @@ function Dashboard() {
   }
 
   const onSubmitTag = async (data) => {
+    const nomeTagNorm = data.nome.trim().toLowerCase()
+    const duplicateTag = tags.find(
+      (t) => t.nome.trim().toLowerCase() === nomeTagNorm && (!editingTag || t.id !== editingTag.id)
+    )
+    if (duplicateTag) {
+      showNotification('Já existe uma tag com esse nome.', 'error')
+      return
+    }
+
     setIsSubmittingTag(true)
     try {
       if (editingTag) {
@@ -1457,9 +1456,8 @@ function Dashboard() {
                                   <tr>
                                     <th>Imagem</th>
                                     <th>Nome do Evento</th>
-                                    <th>Data</th>
-                                    <th>Horário</th>
-                                    <th>Período</th>
+                                    <th>Data do Evento</th>
+                                    <th>Cadastrado em</th>
                                     <th>Ações</th>
                                   </tr>
                                 </thead>
@@ -1493,14 +1491,13 @@ function Dashboard() {
                                             <span className="badge badge-encerrado">Encerrado</span>
                                           )}
                                         </td>
-                                        <td data-label="Data">{evento.data_evento}</td>
-                                        <td data-label="Horário">{evento.horario}</td>
-                                        <td data-label="Período">
-                                          <span
-                                            className={`badge badge-${evento.periodo?.toLowerCase()}`}
-                                          >
-                                            {evento.periodo}
-                                          </span>
+                                        <td data-label="Data do Evento">{evento.data_evento}</td>
+                                        <td data-label="Cadastrado em">
+                                          {evento.created_at
+                                            ? new Date(evento.created_at).toLocaleDateString(
+                                                'pt-BR'
+                                              )
+                                            : '-'}
                                         </td>
                                         <td data-label="Ações">
                                           <div className="action-buttons">

--- a/supabase/migrations/012_moderador_evento_tags.sql
+++ b/supabase/migrations/012_moderador_evento_tags.sql
@@ -1,0 +1,18 @@
+-- =============================================
+-- MIGRATION: Permitir que moderador gerencie evento_tags
+-- Moderador pode associar/desassociar tags de eventos
+-- =============================================
+
+-- Remover politicas antigas que excluiam o moderador
+DROP POLICY IF EXISTS "Admins podem criar evento tags" ON evento_tags;
+DROP POLICY IF EXISTS "Admins podem deletar evento tags" ON evento_tags;
+
+-- INSERT: admins e moderadores podem associar tags a eventos
+CREATE POLICY "Admins e moderadores podem criar evento tags" ON evento_tags
+  FOR INSERT
+  WITH CHECK (has_role(ARRAY['super_admin', 'admin', 'moderador']::app_role[]));
+
+-- DELETE: admins e moderadores podem remover tags de eventos
+CREATE POLICY "Admins e moderadores podem deletar evento tags" ON evento_tags
+  FOR DELETE
+  USING (has_role(ARRAY['super_admin', 'admin', 'moderador']::app_role[]));


### PR DESCRIPTION
- corrige permissão RLS para moderador associar tags a eventos (evento_tags)
- impede cadastro de evento com nome duplicado
- impede cadastro de tag com nome duplicado
- ordena eventos cadastrados por data de criação (mais recente primeiro)
- exibe coluna 'Cadastrado em' na tabela de eventos
- remove colunas Horário e Período da tabela de eventos
- renomeia coluna 'Data' para 'Data do Evento'
- atualiza testes para refletir novo comportamento