### PR TITLE
feat(dashboard): permitir que admin e moderador salvem configurações …

### DIFF
--- a/src/admin/Admin.css
+++ b/src/admin/Admin.css
@@ -384,8 +384,17 @@
 
 .settings-avatar-area {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
   padding: 1rem 0 0.5rem;
+}
+
+.settings-avatar-name {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-align: center;
 }
 
 .settings-avatar-preview {
@@ -448,6 +457,16 @@
   color: var(--text-secondary);
   font-style: italic;
   font-weight: 400;
+}
+
+.settings-github-link {
+  color: var(--primary-blue);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.settings-github-link:hover {
+  text-decoration: underline;
 }
 
 .settings-role-badge {

--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -40,7 +40,7 @@ import {
   GitBranch,
 } from 'lucide-react'
 import { useForm } from 'react-hook-form'
-import { getSession, signOut, getCurrentUser } from '../services/authService'
+import { getSession, signOut } from '../services/authService'
 import {
   getEvents,
   createEvent,
@@ -362,7 +362,7 @@ function Dashboard() {
         return
       }
 
-      const user = await getCurrentUser()
+      const user = session.user
       if (user) {
         setUserEmail(user.email)
         setUserId(user.id)
@@ -646,6 +646,11 @@ function Dashboard() {
         avatar_url: profileGitHubPreview?.avatar_url || null,
       })
       setUserProfile(saved)
+      setProfileGitHubPreview(
+        saved.github_username
+          ? { github_username: saved.github_username, avatar_url: saved.avatar_url }
+          : null
+      )
       setIsEditingProfile(false)
       showNotification('Perfil salvo com sucesso!')
     } catch {
@@ -670,6 +675,11 @@ function Dashboard() {
   }
 
   const handleCancelEditProfile = () => {
+    setProfileGitHubPreview(
+      userProfile?.github_username
+        ? { github_username: userProfile.github_username, avatar_url: userProfile.avatar_url }
+        : null
+    )
     setIsEditingProfile(false)
   }
 
@@ -1877,7 +1887,7 @@ function Dashboard() {
                 <div className="settings-section">
                   <div className="section-header">
                     <h2>Configurações do Perfil</h2>
-                    {!isEditingProfile && (
+                    {!isEditingProfile && permissions.canSaveSettings && (
                       <button
                         className="btn-icon btn-edit"
                         onClick={handleEditProfile}
@@ -1888,7 +1898,7 @@ function Dashboard() {
                     )}
                   </div>
 
-                  {isEditingProfile ? (
+                  {isEditingProfile && permissions.canSaveSettings ? (
                     <form onSubmit={handleSubmitProfile(onSubmitProfile)} className="settings-form">
                       <div className="settings-avatar-area">
                         {profileGitHubPreview?.avatar_url ? (
@@ -1999,6 +2009,12 @@ function Dashboard() {
                             {userEmail?.charAt(0).toUpperCase() || 'A'}
                           </div>
                         )}
+                        {(userProfile?.nome || userProfile?.sobrenome) && (
+                          <div className="settings-avatar-name">
+                            {userProfile.nome}
+                            {userProfile.sobrenome ? ` ${userProfile.sobrenome}` : ''}
+                          </div>
+                        )}
                       </div>
 
                       <div className="settings-profile-info">
@@ -2016,7 +2032,14 @@ function Dashboard() {
                           <span className="settings-info-label">GitHub</span>
                           <span className="settings-info-value">
                             {userProfile?.github_username ? (
-                              `@${userProfile.github_username}`
+                              <a
+                                href={`https://github.com/${userProfile.github_username}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="settings-github-link"
+                              >
+                                @{userProfile.github_username}
+                              </a>
                             ) : (
                               <span className="settings-info-empty">Não informado</span>
                             )}

--- a/src/admin/Dashboard.test.jsx
+++ b/src/admin/Dashboard.test.jsx
@@ -11,7 +11,6 @@ import * as roleService from '../services/roleService'
 vi.mock('../services/authService', () => ({
   getSession: vi.fn(),
   signOut: vi.fn(),
-  getCurrentUser: vi.fn(),
   onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
 }))
 
@@ -94,8 +93,7 @@ describe('Dashboard', () => {
     document.documentElement.removeAttribute('data-theme')
 
     // Setup padrão dos mocks
-    authService.getSession.mockResolvedValue({ user: { id: '1' } })
-    authService.getCurrentUser.mockResolvedValue({ id: 'user-1', email: 'admin@teste.com' })
+    authService.getSession.mockResolvedValue({ user: { id: 'user-1', email: 'admin@teste.com' } })
     eventService.getEvents.mockResolvedValue(mockEvents)
     eventService.getEventStats.mockResolvedValue(mockStats)
     roleService.getCurrentUserRole.mockResolvedValue('super_admin')
@@ -579,7 +577,7 @@ describe('Dashboard', () => {
       expect(screen.getAllByTitle('Editar').length).toBeGreaterThan(0)
     })
 
-    it('admin nao deve ver tab Usuarios na sidebar', async () => {
+    it('admin deve ver tab Usuarios na sidebar', async () => {
       roleService.getCurrentUserRole.mockResolvedValue('admin')
 
       renderWithRouter(<Dashboard />)
@@ -590,7 +588,7 @@ describe('Dashboard', () => {
 
       const sidebarButtons = screen.getAllByRole('button')
       const usuariosBtn = sidebarButtons.find((btn) => btn.textContent.includes('Usuarios'))
-      expect(usuariosBtn).toBeUndefined()
+      expect(usuariosBtn).toBeDefined()
     })
 
     it('super_admin deve ver tab Usuarios na sidebar', async () => {
@@ -629,6 +627,168 @@ describe('Dashboard', () => {
       expect(screen.getByRole('button', { name: /Novo Evento/i })).toBeInTheDocument()
       expect(screen.getAllByTitle('Editar').length).toBeGreaterThan(0)
       expect(screen.getAllByTitle('Excluir').length).toBeGreaterThan(0)
+    })
+  })
+
+  // === Testes de Configurações ===
+  describe('Configurações - Perfil do usuário', () => {
+    const mockProfile = {
+      user_id: 'user-1',
+      nome: 'João',
+      sobrenome: 'Silva',
+      github_username: 'joaosilva',
+      avatar_url: 'https://avatars.githubusercontent.com/u/123',
+      updated_at: '2024-01-01T00:00:00Z',
+    }
+
+    it('deve exibir informações do perfil salvo na aba configurações', async () => {
+      const { getMyProfile } = await import('../services/profileService')
+      getMyProfile.mockResolvedValue(mockProfile)
+
+      const user = userEvent.setup()
+      renderWithRouter(<Dashboard />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Eventos Cadastrados')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /Configurações/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Configurações do Perfil')).toBeInTheDocument()
+        expect(screen.getAllByText(/João Silva/).length).toBeGreaterThanOrEqual(1)
+        expect(screen.getByText('@joaosilva')).toBeInTheDocument()
+      })
+    })
+
+    it('deve exibir botão de editar perfil para admin', async () => {
+      roleService.getCurrentUserRole.mockResolvedValue('admin')
+      const { getMyProfile } = await import('../services/profileService')
+      getMyProfile.mockResolvedValue(mockProfile)
+
+      const user = userEvent.setup()
+      renderWithRouter(<Dashboard />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Eventos Cadastrados')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /Configurações/i }))
+
+      await waitFor(() => {
+        expect(screen.getByTitle('Editar perfil')).toBeInTheDocument()
+      })
+    })
+
+    it('deve exibir botão de editar perfil para moderador', async () => {
+      roleService.getCurrentUserRole.mockResolvedValue('moderador')
+      const { getMyProfile } = await import('../services/profileService')
+      getMyProfile.mockResolvedValue(mockProfile)
+
+      const user = userEvent.setup()
+      renderWithRouter(<Dashboard />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Eventos Cadastrados')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /Configurações/i }))
+
+      await waitFor(() => {
+        expect(screen.getByTitle('Editar perfil')).toBeInTheDocument()
+      })
+    })
+
+    it('deve salvar perfil e refletir na tela', async () => {
+      const { getMyProfile, upsertMyProfile } = await import('../services/profileService')
+      getMyProfile.mockResolvedValue(null)
+      const profileSalvo = {
+        user_id: 'user-1',
+        nome: 'Maria',
+        sobrenome: 'Souza',
+        github_username: null,
+        avatar_url: null,
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      upsertMyProfile.mockResolvedValue(profileSalvo)
+
+      const user = userEvent.setup()
+      renderWithRouter(<Dashboard />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Eventos Cadastrados')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /Configurações/i }))
+
+      await waitFor(() => {
+        expect(screen.getByTitle('Editar perfil')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByTitle('Editar perfil'))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Seu nome')).toBeInTheDocument()
+      })
+
+      await user.clear(screen.getByPlaceholderText('Seu nome'))
+      await user.type(screen.getByPlaceholderText('Seu nome'), 'Maria')
+      await user.clear(screen.getByPlaceholderText('Seu sobrenome'))
+      await user.type(screen.getByPlaceholderText('Seu sobrenome'), 'Souza')
+
+      await user.click(screen.getByRole('button', { name: /Salvar/i }))
+
+      await waitFor(() => {
+        expect(upsertMyProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ nome: 'Maria', sobrenome: 'Souza' })
+        )
+        expect(screen.getAllByText(/Maria Souza/).length).toBeGreaterThanOrEqual(1)
+      })
+    })
+
+    it('deve refletir nome e avatar no sidebar após salvar perfil', async () => {
+      const { getMyProfile, upsertMyProfile } = await import('../services/profileService')
+      getMyProfile.mockResolvedValue(null)
+      const profileSalvo = {
+        user_id: 'user-1',
+        nome: 'Carlos',
+        sobrenome: 'Lima',
+        github_username: null,
+        avatar_url: null,
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      upsertMyProfile.mockResolvedValue(profileSalvo)
+
+      const user = userEvent.setup()
+      renderWithRouter(<Dashboard />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Eventos Cadastrados')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /Configurações/i }))
+
+      await waitFor(() => {
+        expect(screen.getByTitle('Editar perfil')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByTitle('Editar perfil'))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Seu nome')).toBeInTheDocument()
+      })
+
+      await user.clear(screen.getByPlaceholderText('Seu nome'))
+      await user.type(screen.getByPlaceholderText('Seu nome'), 'Carlos')
+      await user.clear(screen.getByPlaceholderText('Seu sobrenome'))
+      await user.type(screen.getByPlaceholderText('Seu sobrenome'), 'Lima')
+
+      await user.click(screen.getByRole('button', { name: /Salvar/i }))
+
+      await waitFor(() => {
+        // nome deve aparecer no sidebar também
+        expect(screen.getAllByText('Carlos Lima').length).toBeGreaterThanOrEqual(1)
+      })
     })
   })
 })

--- a/src/hooks/useUserRole.js
+++ b/src/hooks/useUserRole.js
@@ -12,6 +12,7 @@ const PERMISSIONS = {
     canManageContributors: true,
     canManageUsers: true,
     canUploadImages: true,
+    canSaveSettings: true,
   },
   admin: {
     canCreateEvents: true,
@@ -22,6 +23,7 @@ const PERMISSIONS = {
     canManageContributors: true,
     canManageUsers: true,
     canUploadImages: true,
+    canSaveSettings: true,
   },
   moderador: {
     canCreateEvents: true,
@@ -32,6 +34,7 @@ const PERMISSIONS = {
     canManageContributors: false,
     canManageUsers: false,
     canUploadImages: true,
+    canSaveSettings: true,
   },
 }
 
@@ -44,6 +47,7 @@ const NO_PERMISSIONS = {
   canManageContributors: false,
   canManageUsers: false,
   canUploadImages: false,
+  canSaveSettings: false,
 }
 
 export const ROLE_LABELS = {

--- a/src/services/profileService.js
+++ b/src/services/profileService.js
@@ -1,41 +1,64 @@
 import { supabase } from '../lib/supabase'
+import { withRetry } from '../lib/apiClient'
 
 // Buscar perfil do usuario logado
 export async function getMyProfile() {
-  const { data, error } = await supabase.from('user_profiles').select('*').single()
+  return withRetry(
+    async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
 
-  if (error && error.code !== 'PGRST116') {
-    // PGRST116 = nenhuma linha encontrada (perfil ainda nao criado)
-    console.error('Erro ao buscar perfil:', error)
-    throw error
-  }
+      if (!user) {
+        return null
+      }
 
-  return data || null
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .select('*')
+        .eq('user_id', user.id)
+        .single()
+
+      if (error && error.code !== 'PGRST116') {
+        // PGRST116 = nenhuma linha encontrada (perfil ainda nao criado)
+        console.error('Erro ao buscar perfil:', error)
+        throw error
+      }
+
+      return data || null
+    },
+    { context: 'getMyProfile' }
+  )
 }
 
-// Criar ou atualizar perfil do usuario logado
+// Criar ou atualizar perfil do usuario logado (apenas admin, super_admin e moderador)
 export async function upsertMyProfile({ nome, sobrenome, github_username, avatar_url }) {
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  return withRetry(
+    async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
 
-  if (!user) {
-    throw new Error('Usuário não autenticado')
-  }
+      if (!user) {
+        throw new Error('Usuário não autenticado')
+      }
 
-  const { data, error } = await supabase
-    .from('user_profiles')
-    .upsert(
-      { user_id: user.id, nome, sobrenome, github_username, avatar_url },
-      { onConflict: 'user_id' }
-    )
-    .select()
-    .single()
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .upsert(
+          { user_id: user.id, nome, sobrenome, github_username, avatar_url },
+          { onConflict: 'user_id' }
+        )
+        .select()
+        .single()
 
-  if (error) {
-    console.error('Erro ao salvar perfil:', error)
-    throw error
-  }
+      if (error) {
+        console.error('Erro ao salvar perfil:', error)
+        throw error
+      }
 
-  return data
+      return data
+    },
+    { context: 'upsertMyProfile' }
+  )
 }

--- a/src/services/profileService.test.js
+++ b/src/services/profileService.test.js
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getMyProfile, upsertMyProfile } from './profileService'
+
+// Mock do supabase
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn(),
+    },
+    from: vi.fn(),
+  },
+}))
+
+// Mock do apiClient (withRetry executa a função diretamente)
+vi.mock('../lib/apiClient', () => ({
+  withRetry: vi.fn((fn) => fn()),
+}))
+
+// Mock do sentry (usado internamente pelo apiClient)
+vi.mock('../lib/sentry.js', () => ({
+  captureError: vi.fn(),
+}))
+
+import { supabase } from '../lib/supabase'
+
+const mockProfile = {
+  user_id: 'user-123',
+  nome: 'João',
+  sobrenome: 'Silva',
+  github_username: 'joaosilva',
+  avatar_url: 'https://avatars.githubusercontent.com/u/123',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+const mockUser = { id: 'user-123', email: 'admin@teste.com' }
+
+describe('profileService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    supabase.auth.getUser.mockResolvedValue({ data: { user: mockUser } })
+  })
+
+  describe('getMyProfile', () => {
+    it('deve retornar o perfil do usuário logado', async () => {
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockProfile, error: null }),
+      }
+      supabase.from.mockReturnValue(mockQuery)
+
+      const result = await getMyProfile()
+
+      expect(supabase.from).toHaveBeenCalledWith('user_profiles')
+      expect(mockQuery.eq).toHaveBeenCalledWith('user_id', 'user-123')
+      expect(result).toEqual(mockProfile)
+    })
+
+    it('deve retornar null quando perfil não existe (PGRST116)', async () => {
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+      }
+      supabase.from.mockReturnValue(mockQuery)
+
+      const result = await getMyProfile()
+
+      expect(result).toBeNull()
+    })
+
+    it('deve retornar null quando usuário não está autenticado', async () => {
+      supabase.auth.getUser.mockResolvedValue({ data: { user: null } })
+
+      const result = await getMyProfile()
+
+      expect(result).toBeNull()
+      expect(supabase.from).not.toHaveBeenCalled()
+    })
+
+    it('deve lançar erro para falhas que não sejam PGRST116', async () => {
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: null,
+          error: { code: 'PGRST500', message: 'Erro interno' },
+        }),
+      }
+      supabase.from.mockReturnValue(mockQuery)
+
+      await expect(getMyProfile()).rejects.toMatchObject({ code: 'PGRST500' })
+    })
+  })
+
+  describe('upsertMyProfile', () => {
+    it('deve salvar o perfil e retornar os dados salvos', async () => {
+      const mockQuery = {
+        upsert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockProfile, error: null }),
+      }
+      supabase.from.mockReturnValue(mockQuery)
+
+      const input = {
+        nome: 'João',
+        sobrenome: 'Silva',
+        github_username: 'joaosilva',
+        avatar_url: 'https://avatars.githubusercontent.com/u/123',
+      }
+
+      const result = await upsertMyProfile(input)
+
+      expect(supabase.from).toHaveBeenCalledWith('user_profiles')
+      expect(mockQuery.upsert).toHaveBeenCalledWith(
+        { user_id: 'user-123', ...input },
+        { onConflict: 'user_id' }
+      )
+      expect(result).toEqual(mockProfile)
+    })
+
+    it('deve lançar erro quando usuário não está autenticado', async () => {
+      supabase.auth.getUser.mockResolvedValue({ data: { user: null } })
+
+      await expect(
+        upsertMyProfile({ nome: 'João', sobrenome: '', github_username: null, avatar_url: null })
+      ).rejects.toThrow('Usuário não autenticado')
+    })
+
+    it('deve lançar erro quando o banco retorna erro', async () => {
+      const mockQuery = {
+        upsert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'violação de constraint' },
+        }),
+      }
+      supabase.from.mockReturnValue(mockQuery)
+
+      await expect(
+        upsertMyProfile({ nome: 'João', sobrenome: '', github_username: null, avatar_url: null })
+      ).rejects.toMatchObject({ message: 'violação de constraint' })
+    })
+
+    it('deve salvar com github_username nulo quando não informado', async () => {
+      const profileSemGitHub = { ...mockProfile, github_username: null, avatar_url: null }
+      const mockQuery = {
+        upsert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: profileSemGitHub, error: null }),
+      }
+      supabase.from.mockReturnValue(mockQuery)
+
+      const result = await upsertMyProfile({
+        nome: 'João',
+        sobrenome: 'Silva',
+        github_username: null,
+        avatar_url: null,
+      })
+
+      expect(mockQuery.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ github_username: null, avatar_url: null }),
+        { onConflict: 'user_id' }
+      )
+      expect(result.github_username).toBeNull()
+    })
+  })
+})

--- a/supabase/migrations/013_admin_save_profile.sql
+++ b/supabase/migrations/013_admin_save_profile.sql
@@ -1,0 +1,22 @@
+-- =============================================
+-- MIGRATION: Garantir que admin e moderador possam salvar configurações de perfil
+-- A policy original (009) usava apenas auth.uid() = user_id sem WITH CHECK no UPDATE
+-- Esta migration corrige adicionando WITH CHECK e mantendo o acesso para todos os roles válidos
+-- =============================================
+
+-- 1. Remover policies existentes de INSERT e UPDATE (criadas na 009 e tentativas anteriores)
+DROP POLICY IF EXISTS "Usuario pode criar seu proprio perfil" ON user_profiles;
+DROP POLICY IF EXISTS "Usuario pode atualizar seu proprio perfil" ON user_profiles;
+DROP POLICY IF EXISTS "Usuario autenticado pode criar seu proprio perfil" ON user_profiles;
+DROP POLICY IF EXISTS "Usuario autenticado pode atualizar seu proprio perfil" ON user_profiles;
+
+-- 2. Nova policy de INSERT: qualquer usuário autenticado insere o próprio perfil
+CREATE POLICY "Usuario autenticado pode criar seu proprio perfil"
+  ON user_profiles FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- 3. Nova policy de UPDATE com WITH CHECK explícito (corrige upsert via .upsert())
+CREATE POLICY "Usuario autenticado pode atualizar seu proprio perfil"
+  ON user_profiles FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
…de perfil

- Adiciona canSaveSettings em useUserRole para super_admin, admin e moderador
- Migration 013: corrige policies INSERT/UPDATE em user_profiles com WITH CHECK
- profileService: usa .eq('user_id') explícito para carregar perfil corretamente
- Dashboard init: usa session.user diretamente, remove chamada duplicada
- Configurações: exibe nome abaixo do avatar e GitHub como link clicável
- Após salvar, profileGitHubPreview é atualizado refletindo imediatamente
- Cria profileService.test.js com 8 testes de getMyProfile e upsertMyProfile
- Dashboard.test.jsx: 5 novos testes de configurações e mocks corrigidos