### PR TITLE
fix(eventcard): corrige imagem não cobrindo o card completamente

### DIFF
--- a/src/components/EventCard.css
+++ b/src/components/EventCard.css
@@ -54,22 +54,27 @@
 }
 
 /* Imagem */
+.ec-image-wrapper {
+  width: 100%;
+  flex-shrink: 0;
+}
+
 .ec-image {
   position: relative;
   overflow: hidden;
+  width: 100%;
 }
 
 .ec-card--compact .ec-image {
   height: 160px;
-  aspect-ratio: 16 / 9;
 }
 
 .ec-card--full .ec-image {
   height: 200px;
-  aspect-ratio: 16 / 9;
 }
 
 .ec-image img {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -216,11 +221,14 @@
     flex-direction: row;
   }
 
-  .ec-card--compact .ec-image {
+  .ec-card--compact .ec-image-wrapper {
     width: 120px;
-    height: auto;
-    min-height: 120px;
     flex-shrink: 0;
+  }
+
+  .ec-card--compact .ec-image {
+    height: 100%;
+    min-height: 120px;
   }
 
   .ec-card--compact .ec-content {
@@ -262,8 +270,11 @@
 }
 
 @media (max-width: 480px) {
-  .ec-card--compact .ec-image {
+  .ec-card--compact .ec-image-wrapper {
     width: 100px;
+  }
+
+  .ec-card--compact .ec-image {
     min-height: 100px;
   }
 

--- a/src/components/EventCard.jsx
+++ b/src/components/EventCard.jsx
@@ -60,30 +60,32 @@ function EventCard({
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
       style={style}
     >
-      <div className="ec-image">
-        <img
-          src={event.imagem || BgEventos}
-          alt={event.nome}
-          loading="lazy"
-          decoding="async"
-          onError={(e) => {
-            e.target.src = BgEventos
-          }}
-        />
-        <div className={badgeClass}>{badgeText}</div>
-        {tags.length > 0 && (
-          <div className="card-image-tags">
-            {tags.map((tag) => (
-              <span
-                key={tag.id}
-                className="card-image-tag"
-                style={{ '--tag-color': tag.cor || '#2563eb' }}
-              >
-                {tag.nome}
-              </span>
-            ))}
-          </div>
-        )}
+      <div className="ec-image-wrapper">
+        <div className="ec-image">
+          <img
+            src={event.imagem || BgEventos}
+            alt={event.nome}
+            loading="lazy"
+            decoding="async"
+            onError={(e) => {
+              e.target.src = BgEventos
+            }}
+          />
+          <div className={badgeClass}>{badgeText}</div>
+          {tags.length > 0 && (
+            <div className="card-image-tags">
+              {tags.map((tag) => (
+                <span
+                  key={tag.id}
+                  className="card-image-tag"
+                  style={{ '--tag-color': tag.cor || '#2563eb' }}
+                >
+                  {tag.nome}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="ec-content">

--- a/src/pages/EventDetails.css
+++ b/src/pages/EventDetails.css
@@ -250,7 +250,6 @@
 .event-image-container {
   position: relative;
   height: 400px;
-  aspect-ratio: 16 / 9;
   overflow: hidden;
 }
 
@@ -321,6 +320,7 @@
   font-size: 1.125rem;
   color: var(--text-secondary);
   line-height: 1.7;
+  text-align: justify;
 }
 
 /* Info Grid */


### PR DESCRIPTION
Adiciona wrapper `.ec-image-wrapper` com `width: 100%` para garantir que o container da imagem ocupe sempre a largura total do card. Remove o `aspect-ratio` que conflitava com o `height` fixo e causava área descoberta. Inclui `display: block` na img para eliminar espaço inline do browser.

Também remove `aspect-ratio` do `.event-image-container` em EventDetails.css e adiciona `text-align: justify` na descrição do evento.