### PR TITLE
feat: adiciona visualização em calendário mensal na página de eventos

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -560,6 +560,52 @@ section {
   padding-top: 10rem;
 }
 
+/* FAB Favoritos — mobile only */
+.fab-favourites {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .fab-favourites {
+    display: flex;
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 1.5rem;
+    width: 60px;
+    height: 60px;
+    border-radius: 16px;
+    background: var(--primary-blue);
+    border: none;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    box-shadow:
+      0 4px 12px rgba(37, 99, 235, 0.4),
+      0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 1103;
+  }
+
+  .fab-favourites:active {
+    transform: translateY(-50%) scale(0.95);
+  }
+
+  .fab-favourites--active {
+    background: #1e293b;
+    color: #fff;
+    box-shadow:
+      0 4px 12px rgba(0, 0, 0, 0.3),
+      0 2px 4px rgba(0, 0, 0, 0.15);
+  }
+
+  [data-theme='dark'] .fab-favourites--active {
+    background: #f1f5f9;
+    color: #1e293b;
+  }
+}
+
 /* Eventos Filters */
 .eventos-filters {
   display: flex;

--- a/src/components/CalendarView/CalendarDay.jsx
+++ b/src/components/CalendarView/CalendarDay.jsx
@@ -1,0 +1,63 @@
+import { isEventPast, isEventToday } from '../../utils/eventDate'
+
+const MAX_DOTS_DESKTOP = 3
+const MAX_DOTS_MOBILE = 2
+
+function renderDots(events, maxDots) {
+  const count = Math.min(events.length, maxDots)
+  const dots = Array.from({ length: count }).map((_, i) => {
+    const isPast = isEventPast(events[i].data_evento)
+    return <span key={i} className={`cal-dot${isPast ? ' cal-dot--past' : ''}`} />
+  })
+  const extra = events.length - maxDots
+  return (
+    <>
+      {dots}
+      {extra > 0 && <span className="cal-dot-more">+{extra}</span>}
+    </>
+  )
+}
+
+export default function CalendarDay({ day, currentMonth, isToday, events, onClick }) {
+  const hasEvents = events.length > 0
+  const allPast = hasEvents && events.every((e) => isEventPast(e.data_evento))
+  const hasLive = hasEvents && events.some((e) => isEventToday(e.data_evento))
+
+  const classNames = [
+    'cal-day',
+    !currentMonth && 'cal-day--other-month',
+    isToday && 'cal-day--today',
+    hasEvents && 'cal-day--has-events',
+    hasEvents && !allPast && 'cal-day--upcoming',
+    allPast && 'cal-day--past-events',
+    hasLive && 'cal-day--live',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div
+      className={classNames}
+      onClick={hasEvents ? onClick : undefined}
+      role={hasEvents ? 'button' : undefined}
+      tabIndex={hasEvents ? 0 : undefined}
+      onKeyDown={hasEvents ? (e) => (e.key === 'Enter' || e.key === ' ') && onClick() : undefined}
+      aria-label={
+        hasEvents ? `${day}, ${events.length} evento${events.length > 1 ? 's' : ''}` : String(day)
+      }
+    >
+      <span className="cal-day-number">{day}</span>
+
+      {hasEvents && (
+        <>
+          <div className="cal-day-dots cal-day-dots--desktop">
+            {renderDots(events, MAX_DOTS_DESKTOP)}
+          </div>
+          <div className="cal-day-dots cal-day-dots--mobile">
+            {renderDots(events, MAX_DOTS_MOBILE)}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/CalendarView/CalendarDayModal.jsx
+++ b/src/components/CalendarView/CalendarDayModal.jsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { X } from 'lucide-react'
+import CalendarEventItem from './CalendarEventItem'
+import './CalendarEventItem.css'
+
+const DAY_NAMES = [
+  'Domingo',
+  'Segunda-feira',
+  'Terça-feira',
+  'Quarta-feira',
+  'Quinta-feira',
+  'Sexta-feira',
+  'Sábado',
+]
+const MONTH_NAMES = [
+  'janeiro',
+  'fevereiro',
+  'março',
+  'abril',
+  'maio',
+  'junho',
+  'julho',
+  'agosto',
+  'setembro',
+  'outubro',
+  'novembro',
+  'dezembro',
+]
+
+function formatModalDate(date) {
+  return `${DAY_NAMES[date.getDay()]}, ${date.getDate()} de ${MONTH_NAMES[date.getMonth()]} de ${date.getFullYear()}`
+}
+
+export default function CalendarDayModal({
+  date,
+  events,
+  eventTagsMap,
+  favouriteIds,
+  toggleFavourite,
+  onClose,
+}) {
+  const onCloseRef = useRef(onClose)
+  const closeBtnRef = useRef(null)
+  const triggerRef = useRef(typeof document !== 'undefined' ? document.activeElement : null)
+
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === 'Escape') {
+        onCloseRef.current()
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    document.body.style.overflow = 'hidden'
+    closeBtnRef.current?.focus()
+    const trigger = triggerRef.current
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = ''
+      if (trigger && typeof trigger.focus === 'function') {
+        trigger.focus()
+      }
+    }
+  }, [])
+
+  const modal = (
+    <div className="cal-modal-overlay" onClick={onClose}>
+      <div
+        className="cal-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Eventos de ${formatModalDate(date)}`}
+      >
+        <div className="cal-modal-header">
+          <div>
+            <h4 className="cal-modal-title">
+              {events.length} evento{events.length > 1 ? 's' : ''} neste dia
+            </h4>
+            <p className="cal-modal-date">{formatModalDate(date)}</p>
+          </div>
+          <button
+            ref={closeBtnRef}
+            className="cal-modal-close"
+            onClick={onClose}
+            aria-label="Fechar"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="cal-modal-body">
+          {events.length === 0 ? (
+            <p style={{ textAlign: 'center', color: 'var(--text-secondary)', padding: '1.5rem 0' }}>
+              Nenhum evento neste dia.
+            </p>
+          ) : (
+            events.map((event) => {
+              const tags = eventTagsMap?.[String(event.id)] || []
+              return (
+                <CalendarEventItem
+                  key={event.id}
+                  event={event}
+                  tags={tags}
+                  favouriteIds={favouriteIds ?? new Set()}
+                  toggleFavourite={toggleFavourite ?? (() => {})}
+                  onNavigate={onClose}
+                />
+              )
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  )
+
+  return createPortal(modal, document.body)
+}

--- a/src/components/CalendarView/CalendarEventItem.css
+++ b/src/components/CalendarView/CalendarEventItem.css
@@ -1,0 +1,192 @@
+/* ── CalendarEventItem — layout horizontal fixo ─────────────────── */
+:root {
+  --green-happening: #15803d;
+}
+
+.cei-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.cei-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px var(--shadow-hover);
+}
+
+.cei-item:focus-visible {
+  outline: 2px solid var(--primary-blue);
+  outline-offset: 2px;
+}
+
+.cei-item--past {
+  opacity: 0.6;
+  filter: grayscale(70%);
+}
+
+/* ── Imagem ────────────────────────────────────────────────────── */
+.cei-image {
+  position: relative;
+  width: 130px;
+  min-width: 130px;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.cei-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+  transition: transform 0.3s ease;
+}
+
+.cei-item:hover .cei-image img {
+  transform: scale(1.05);
+}
+
+.cei-image::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(transparent 50%, rgba(0, 0, 0, 0.45));
+  pointer-events: none;
+}
+
+/* ── Badge ─────────────────────────────────────────────────────── */
+.cei-badge {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  background: var(--primary-blue);
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.25rem;
+  z-index: 2;
+  white-space: nowrap;
+}
+
+.cei-badge--past {
+  background: var(--text-secondary);
+}
+
+.cei-badge--today {
+  background: var(--green-happening);
+}
+
+/* ── Conteúdo ──────────────────────────────────────────────────── */
+.cei-content {
+  flex: 1;
+  min-width: 0;
+  padding: 0.875rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cei-top {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.cei-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ── Tags ──────────────────────────────────────────────────────── */
+.cei-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.cei-tag {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.25rem;
+  background: color-mix(in srgb, var(--tag-color) 15%, transparent);
+  color: var(--tag-color);
+  border: 1px solid color-mix(in srgb, var(--tag-color) 30%, transparent);
+  white-space: nowrap;
+}
+
+/* ── Info row ──────────────────────────────────────────────────── */
+.cei-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem 0.875rem;
+  margin-top: auto;
+}
+
+.cei-info-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.cei-info-item svg {
+  color: var(--primary-blue);
+  flex-shrink: 0;
+}
+
+/* ── Ações ─────────────────────────────────────────────────────── */
+.cei-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+/* Sobrescreve tamanho do participate-button para caber no card */
+.cei-actions .participate-button {
+  font-size: 0.8125rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  width: auto;
+}
+
+/* Oculta a data em todos os tamanhos (já aparece no cabeçalho do modal) */
+.cei-info-item--date {
+  display: none;
+}
+
+/* ── Mobile ────────────────────────────────────────────────────── */
+@media (max-width: 480px) {
+  .cei-image {
+    width: 100px;
+    min-width: 100px;
+  }
+
+  .cei-title {
+    font-size: 0.875rem;
+  }
+
+  .cei-content {
+    padding: 0.75rem;
+  }
+}

--- a/src/components/CalendarView/CalendarEventItem.jsx
+++ b/src/components/CalendarView/CalendarEventItem.jsx
@@ -1,0 +1,125 @@
+import { useNavigate } from 'react-router-dom'
+import { Calendar, Clock, MapPin, Wifi, Video, Monitor, ArrowUpRight } from 'lucide-react'
+import BgEventos from '../../assets/eventos.png'
+import { FavouriteEventButton } from '../FavouriteEventButton'
+import { isEventPast, isEventToday } from '../../utils/eventDate'
+
+function ModalidadeIcon({ modalidade }) {
+  if (modalidade === 'Online') {
+    return <Wifi size={13} />
+  }
+  if (modalidade === 'Híbrido') {
+    return <Video size={13} />
+  }
+  return <Monitor size={13} />
+}
+
+export default function CalendarEventItem({
+  event,
+  tags = [],
+  favouriteIds,
+  toggleFavourite,
+  onNavigate,
+}) {
+  const navigate = useNavigate()
+  const isPast = isEventPast(event?.data_evento)
+  const isToday = isEventToday(event?.data_evento)
+
+  function handleClick() {
+    if (onNavigate) {
+      onNavigate()
+    }
+    navigate(`/eventos/${event?.id}`)
+  }
+
+  const badgeText = isPast ? 'Encerrado' : isToday ? 'Hoje' : event?.periodo
+  const badgeClass = `cei-badge${isPast ? ' cei-badge--past' : isToday ? ' cei-badge--today' : ''}`
+
+  return (
+    <div
+      className={`cei-item${isPast ? ' cei-item--past' : ''}`}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleClick()}
+    >
+      <div className="cei-image">
+        <img
+          src={event?.imagem || BgEventos}
+          alt={event?.nome ?? ''}
+          loading="lazy"
+          onError={(e) => {
+            e.target.src = BgEventos
+          }}
+        />
+        {badgeText && <span className={badgeClass}>{badgeText}</span>}
+      </div>
+
+      <div className="cei-content">
+        <div className="cei-top">
+          <h4 className="cei-title">{event?.nome ?? ''}</h4>
+          {tags.length > 0 && (
+            <div className="cei-tags">
+              {tags.map((tag) => (
+                <span
+                  key={tag.id}
+                  className="cei-tag"
+                  style={{ '--tag-color': tag.cor || '#2563eb' }}
+                >
+                  {tag.nome}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="cei-info">
+          <span className="cei-info-item cei-info-item--date">
+            <Calendar size={12} />
+            {event?.data_evento}
+          </span>
+          <span className="cei-info-item">
+            <Clock size={12} />
+            {event?.horario}
+          </span>
+          {event?.modalidade && (
+            <span className="cei-info-item">
+              <ModalidadeIcon modalidade={event.modalidade} />
+              {event.modalidade}
+            </span>
+          )}
+          {event?.cidade && event?.modalidade !== 'Online' && (
+            <span className="cei-info-item">
+              <MapPin size={12} />
+              {[event.cidade, event.estado].filter(Boolean).join(' - ')}
+            </span>
+          )}
+        </div>
+
+        <div className="cei-actions" onClick={(e) => e.stopPropagation()}>
+          {isPast ? (
+            <button className="participate-button cei-participate disabled" onClick={handleClick}>
+              Ver detalhes
+            </button>
+          ) : (
+            <a
+              href={event?.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="participate-button cei-participate"
+            >
+              Saber mais
+              <ArrowUpRight size={15} />
+            </a>
+          )}
+          <FavouriteEventButton
+            event={event}
+            isFavourite={favouriteIds.has(event?.id)}
+            onToggle={toggleFavourite}
+            isCard={true}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/CalendarView/CalendarView.css
+++ b/src/components/CalendarView/CalendarView.css
@@ -1,0 +1,376 @@
+/* ── Calendar Container ─────────────────────────────────────────── */
+.calendar-view {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto 3rem;
+  padding: 0 2rem;
+  box-sizing: border-box;
+}
+
+.calendar-inner {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+/* ── Header ─────────────────────────────────────────────────────── */
+.calendar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--background);
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.calendar-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.calendar-nav-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.calendar-nav-btn:hover {
+  background: var(--primary-blue);
+  border-color: var(--primary-blue);
+  color: #fff;
+}
+
+.calendar-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 10rem;
+  text-align: center;
+  margin: 0;
+}
+
+.calendar-today-btn {
+  padding: 0.375rem 0.875rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.calendar-today-btn:hover {
+  background: var(--primary-blue);
+  border-color: var(--primary-blue);
+  color: #fff;
+}
+
+/* ── Grid ───────────────────────────────────────────────────────── */
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+
+.calendar-day-header {
+  padding: 0.625rem 0.25rem;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--border);
+  background: var(--background);
+}
+
+/* ── Day Cell ───────────────────────────────────────────────────── */
+.cal-day {
+  position: relative;
+  min-height: 5rem;
+  padding: 0.5rem 0.375rem 0.375rem;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  transition: background 0.15s ease;
+}
+
+.cal-day:nth-child(7n) {
+  border-right: none;
+}
+
+.cal-day--other-month {
+  opacity: 0.35;
+}
+
+.cal-day--has-events {
+  cursor: pointer;
+}
+
+.cal-day--has-events:hover {
+  background: color-mix(in srgb, var(--primary-blue) 6%, transparent);
+}
+
+.cal-day--today .cal-day-number {
+  background: var(--primary-blue);
+  color: #fff;
+  border-radius: 50%;
+  width: 1.75rem;
+  height: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
+.cal-day--live {
+  background: color-mix(in srgb, #22c55e 8%, transparent);
+}
+
+.cal-day-number {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1;
+  min-width: 1.75rem;
+  min-height: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Dots ───────────────────────────────────────────────────────── */
+.cal-day-dots {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-wrap: wrap;
+}
+
+.cal-day-dots--mobile {
+  display: none;
+}
+
+.cal-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--primary-blue);
+  flex-shrink: 0;
+}
+
+.cal-dot--past {
+  background: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.cal-dot-more {
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  line-height: 1;
+}
+
+/* ── Day Modal Overlay ──────────────────────────────────────────── */
+@keyframes cal-overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes cal-modal-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes cal-modal-scale {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+/* Mobile-first: bottom sheet */
+.cal-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 2000;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  animation: cal-overlay-in 0.2s ease forwards;
+}
+
+.cal-modal {
+  background: var(--background);
+  border-radius: 1.25rem 1.25rem 0 0;
+  width: 100%;
+  max-width: 560px;
+  max-height: 88vh;
+  max-height: 88dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: cal-modal-up 0.28s cubic-bezier(0.34, 1.4, 0.64, 1) forwards;
+}
+
+/* Desktop: modal centralizado */
+@media (min-width: 769px) {
+  .cal-modal-overlay {
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+  }
+
+  .cal-modal {
+    border-radius: 1rem;
+    width: 100%;
+    max-width: 600px;
+    max-height: 80vh;
+    animation: cal-modal-scale 0.22s ease forwards;
+  }
+}
+
+.cal-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1.25rem 1.25rem 1rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.cal-modal-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.2rem;
+}
+
+.cal-modal-date {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.cal-modal-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all 0.15s ease;
+}
+
+.cal-modal-close:hover {
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.cal-modal-body {
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .cal-day {
+    min-height: 3.25rem;
+    padding: 0.375rem 0.25rem 0.25rem;
+  }
+
+  .cal-day-number {
+    font-size: 0.75rem;
+    min-width: 1.5rem;
+    min-height: 1.5rem;
+  }
+
+  .cal-day--today .cal-day-number {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .cal-day-dots--desktop {
+    display: none;
+  }
+
+  .cal-day-dots--mobile {
+    display: flex;
+  }
+
+  .cal-dot {
+    width: 5px;
+    height: 5px;
+  }
+
+  .calendar-day-header {
+    font-size: 0.6875rem;
+    padding: 0.5rem 0.125rem;
+  }
+
+  .calendar-title {
+    font-size: 0.9375rem;
+    min-width: 8.5rem;
+  }
+}
+
+@media (max-width: 400px) {
+  .cal-day {
+    min-height: 2.75rem;
+    padding: 0.25rem 0.125rem;
+  }
+
+  .calendar-day-header {
+    font-size: 0.625rem;
+  }
+
+  .cal-day-number {
+    font-size: 0.6875rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cal-modal-overlay {
+    animation: none;
+  }
+
+  .cal-modal {
+    animation: none;
+  }
+}

--- a/src/components/CalendarView/CalendarView.jsx
+++ b/src/components/CalendarView/CalendarView.jsx
@@ -1,0 +1,177 @@
+import { useState, useMemo } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { parseEventDate, getToday } from '../../utils/eventDate'
+import CalendarDay from './CalendarDay'
+import CalendarDayModal from './CalendarDayModal'
+import './CalendarView.css'
+
+const MONTH_NAMES = [
+  'Janeiro',
+  'Fevereiro',
+  'Março',
+  'Abril',
+  'Maio',
+  'Junho',
+  'Julho',
+  'Agosto',
+  'Setembro',
+  'Outubro',
+  'Novembro',
+  'Dezembro',
+]
+const DAY_HEADERS = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb']
+
+function buildCalendarGrid(year, month) {
+  const firstDay = new Date(year, month, 1)
+  const lastDay = new Date(year, month + 1, 0)
+  const startOffset = firstDay.getDay()
+  const totalDays = lastDay.getDate()
+
+  const cells = []
+
+  // Dias do mês anterior
+  const prevLastDay = new Date(year, month, 0).getDate()
+  for (let i = startOffset - 1; i >= 0; i--) {
+    cells.push({
+      day: prevLastDay - i,
+      currentMonth: false,
+      date: new Date(year, month - 1, prevLastDay - i),
+    })
+  }
+
+  // Dias do mês atual
+  for (let d = 1; d <= totalDays; d++) {
+    cells.push({ day: d, currentMonth: true, date: new Date(year, month, d) })
+  }
+
+  // Dias do próximo mês para completar a grade
+  const remaining = 42 - cells.length
+  for (let d = 1; d <= remaining; d++) {
+    cells.push({ day: d, currentMonth: false, date: new Date(year, month + 1, d) })
+  }
+
+  return cells
+}
+
+function dateKey(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+export default function CalendarView({ events, eventTagsMap, favouriteIds, toggleFavourite }) {
+  const today = getToday()
+  const [currentYear, setCurrentYear] = useState(today.getFullYear())
+  const [currentMonth, setCurrentMonth] = useState(today.getMonth())
+  const [selectedDay, setSelectedDay] = useState(null)
+
+  const eventsByDate = useMemo(() => {
+    const map = {}
+    events.forEach((event) => {
+      const date = parseEventDate(event.data_evento)
+      if (!date) {
+        return
+      }
+      const key = dateKey(date)
+      if (!map[key]) {
+        map[key] = []
+      }
+      map[key].push(event)
+    })
+    return map
+  }, [events])
+
+  const grid = useMemo(
+    () => buildCalendarGrid(currentYear, currentMonth),
+    [currentYear, currentMonth]
+  )
+
+  function prevMonth() {
+    if (currentMonth === 0) {
+      setCurrentMonth(11)
+      setCurrentYear((y) => y - 1)
+    } else {
+      setCurrentMonth((m) => m - 1)
+    }
+  }
+
+  function nextMonth() {
+    if (currentMonth === 11) {
+      setCurrentMonth(0)
+      setCurrentYear((y) => y + 1)
+    } else {
+      setCurrentMonth((m) => m + 1)
+    }
+  }
+
+  function goToToday() {
+    setCurrentYear(today.getFullYear())
+    setCurrentMonth(today.getMonth())
+  }
+
+  function handleDayClick(cell) {
+    const key = dateKey(cell.date)
+    const dayEvents = eventsByDate[key] || []
+    if (dayEvents.length > 0) {
+      setSelectedDay({ date: cell.date, events: dayEvents })
+    }
+  }
+
+  const todayKey = dateKey(today)
+
+  return (
+    <div className="calendar-view">
+      <div className="calendar-inner">
+        <div className="calendar-header">
+          <div className="calendar-nav">
+            <button className="calendar-nav-btn" onClick={prevMonth} aria-label="Mês anterior">
+              <ChevronLeft size={18} />
+            </button>
+            <h3 className="calendar-title">
+              {MONTH_NAMES[currentMonth]} {currentYear}
+            </h3>
+            <button className="calendar-nav-btn" onClick={nextMonth} aria-label="Próximo mês">
+              <ChevronRight size={18} />
+            </button>
+          </div>
+          <button className="calendar-today-btn" onClick={goToToday}>
+            Hoje
+          </button>
+        </div>
+
+        <div className="calendar-grid">
+          {DAY_HEADERS.map((d) => (
+            <div key={d} className="calendar-day-header">
+              {d}
+            </div>
+          ))}
+
+          {grid.map((cell) => {
+            const key = dateKey(cell.date)
+            const dayEvents = eventsByDate[key] || []
+            const isToday = key === todayKey
+            return (
+              <CalendarDay
+                key={key}
+                day={cell.day}
+                currentMonth={cell.currentMonth}
+                isToday={isToday}
+                events={dayEvents}
+                onClick={() => handleDayClick(cell)}
+              />
+            )
+          })}
+        </div>
+      </div>
+
+      {selectedDay && (
+        <CalendarDayModal
+          date={selectedDay.date}
+          events={selectedDay.events}
+          eventTagsMap={eventTagsMap}
+          favouriteIds={favouriteIds}
+          toggleFavourite={toggleFavourite}
+          onClose={() => setSelectedDay(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/CalendarView/index.js
+++ b/src/components/CalendarView/index.js
@@ -1,0 +1,1 @@
+export { default } from './CalendarView'

--- a/src/components/EventsFilters.jsx
+++ b/src/components/EventsFilters.jsx
@@ -1,4 +1,5 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Search, Filter, Heart } from 'lucide-react'
 import SearchModal from './SearchModal'
 import FilterModal from './FilterModal'
@@ -18,6 +19,7 @@ export default function EventsFilters({
   filterActiveCount,
   showOnlyFavourites,
   onToggleFavourites,
+  favouriteIds,
   viewMode,
   onChangeViewMode,
   tags,
@@ -28,15 +30,19 @@ export default function EventsFilters({
   const [searchModalOpen, setSearchModalOpen] = useState(false)
   const searchInputRef = useRef(null)
 
+  useEffect(() => {
+    if (searchOpen) {
+      searchInputRef.current?.focus()
+    }
+  }, [searchOpen])
+
   function handleSearchToggle() {
     if (isMobile) {
       setSearchModalOpen(true)
       return
     }
     setSearchOpen((prev) => {
-      if (!prev) {
-        setTimeout(() => searchInputRef.current?.focus(), 50)
-      } else {
+      if (prev) {
         onSearchChange('')
       }
       return !prev
@@ -89,14 +95,32 @@ export default function EventsFilters({
         <span>Filtros</span>
       </button>
 
-      <button
-        className={`filter-toggle ${showOnlyFavourites ? 'active' : ''}`}
-        onClick={onToggleFavourites}
-        title="Favoritos"
-      >
-        <Heart size={18} fill={showOnlyFavourites ? 'currentColor' : 'none'} />
-        <span>Favoritos</span>
-      </button>
+      {/* Desktop: botão favoritos no filtro — só aparece se houver favoritos */}
+      {!isMobile && favouriteIds?.size > 0 && (
+        <button
+          className={`filter-toggle ${showOnlyFavourites ? 'active' : ''}`}
+          onClick={onToggleFavourites}
+          title="Favoritos"
+        >
+          <Heart size={18} fill={showOnlyFavourites ? 'currentColor' : 'none'} />
+          <span>Favoritos</span>
+        </button>
+      )}
+
+      {/* Mobile: FAB flutuante na esquerda — só aparece se houver favoritos */}
+      {isMobile &&
+        favouriteIds?.size > 0 &&
+        createPortal(
+          <button
+            className={`fab-favourites${showOnlyFavourites ? ' fab-favourites--active' : ''}`}
+            onClick={onToggleFavourites}
+            aria-label="Favoritos"
+            title="Favoritos"
+          >
+            <Heart size={22} fill={showOnlyFavourites ? 'currentColor' : 'none'} />
+          </button>,
+          document.body
+        )}
 
       <ViewToggle
         viewMode={isMobile && viewMode === 'grid' ? 'list' : viewMode}

--- a/src/components/EventsGrid.jsx
+++ b/src/components/EventsGrid.jsx
@@ -2,6 +2,7 @@ import { Calendar } from 'lucide-react'
 import EventCard from './EventCard'
 import EventRowCompact from './EventRowCompact'
 import Pagination from './Pagination'
+import CalendarView from './CalendarView'
 import { isEventPast, isEventToday } from '../utils/eventDate'
 
 function SkeletonCards({ count }) {
@@ -64,6 +65,7 @@ export default function EventsGrid({
   error,
   onRetry,
   filteredEvents,
+  allEvents,
   totalEvents,
   viewMode,
   pageSize,
@@ -77,6 +79,21 @@ export default function EventsGrid({
   if (error) {
     return <ErrorState onRetry={onRetry} />
   }
+
+  if (viewMode === 'calendar') {
+    if ((allEvents ?? filteredEvents).length === 0) {
+      return <EmptyState hasEvents={totalEvents > 0} />
+    }
+    return (
+      <CalendarView
+        events={allEvents ?? filteredEvents}
+        eventTagsMap={eventTagsMap}
+        favouriteIds={favouriteIds}
+        toggleFavourite={toggleFavourite}
+      />
+    )
+  }
+
   if (filteredEvents.length === 0) {
     return <EmptyState hasEvents={totalEvents > 0} />
   }

--- a/src/components/ViewToggle.jsx
+++ b/src/components/ViewToggle.jsx
@@ -1,10 +1,11 @@
-import { LayoutGrid, List, AlignJustify } from 'lucide-react'
+import { LayoutGrid, List, AlignJustify, CalendarDays } from 'lucide-react'
 import './ViewToggle.css'
 
 const MODES = [
   { id: 'grid', icon: LayoutGrid, label: 'Grade', mobileOnly: false },
   { id: 'list', icon: List, label: 'Lista', mobileOnly: false },
   { id: 'compact', icon: AlignJustify, label: 'Compacto', mobileOnly: false },
+  { id: 'calendar', icon: CalendarDays, label: 'Calendário', mobileOnly: false },
 ]
 
 export default function ViewToggle({ viewMode, onChange, isMobile }) {

--- a/src/hooks/useViewMode.js
+++ b/src/hooks/useViewMode.js
@@ -1,14 +1,15 @@
 import { useState } from 'react'
 
 const STORAGE_KEY = 'eventos-view-mode'
-const VALID_MODES = ['grid', 'list', 'compact']
+const VALID_MODES = ['grid', 'list', 'compact', 'calendar']
 
 export default function useViewMode(defaultMode = 'grid') {
   const [viewMode, setViewMode] = useState(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY)
       return VALID_MODES.includes(stored) ? stored : defaultMode
-    } catch {
+    } catch (err) {
+      console.warn('[useViewMode] Failed to read from localStorage:', err)
       return defaultMode
     }
   })
@@ -20,8 +21,8 @@ export default function useViewMode(defaultMode = 'grid') {
     setViewMode(mode)
     try {
       localStorage.setItem(STORAGE_KEY, mode)
-    } catch {
-      // ignore
+    } catch (err) {
+      console.warn('[useViewMode] Failed to write to localStorage:', err)
     }
   }
 

--- a/src/pages/EventsPage.jsx
+++ b/src/pages/EventsPage.jsx
@@ -103,6 +103,7 @@ export default function EventsPage() {
             filterActiveCount={filterActiveCount}
             showOnlyFavourites={showOnlyFavourites}
             onToggleFavourites={() => setShowOnlyFavourites((v) => !v)}
+            favouriteIds={favouriteIds}
             viewMode={viewMode}
             onChangeViewMode={changeViewMode}
             tags={allTags}
@@ -114,6 +115,7 @@ export default function EventsPage() {
             error={error}
             onRetry={revalidate}
             filteredEvents={pagedItems}
+            allEvents={viewMode === 'calendar' ? filteredEvents : undefined}
             totalEvents={agenda.length}
             viewMode={viewMode}
             pageSize={pageSize}
@@ -122,7 +124,7 @@ export default function EventsPage() {
             toggleFavourite={toggleFavourite}
           />
 
-          {!loading && !error && filteredEvents.length > 0 && (
+          {!loading && !error && filteredEvents.length > 0 && viewMode !== 'calendar' && (
             <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={goToPage} />
           )}
         </section>

--- a/src/utils/eventDate.js
+++ b/src/utils/eventDate.js
@@ -57,17 +57,49 @@ export function isEventToday(dataEvento) {
  * Ordena eventos: futuros primeiro (por proximidade), passados depois (mais recente primeiro).
  * Não muta o array original.
  */
+function parseTimeMinutes(horario) {
+  if (!horario) {
+    return 0
+  }
+  const match = horario.match(/(\d{1,2}):(\d{2})/)
+  if (!match) {
+    return 0
+  }
+  const hours = Number(match[1])
+  const minutes = Number(match[2])
+  if (hours > 23 || minutes > 59) {
+    return 0
+  }
+  return hours * 60 + minutes
+}
+
 export function sortEventsByDate(events) {
   const today = getToday()
   return [...events].sort((a, b) => {
-    const dateA = parseEventDate(a.data_evento) ?? new Date(0)
-    const dateB = parseEventDate(b.data_evento) ?? new Date(0)
+    const dateA = parseEventDate(a.data_evento)
+    const dateB = parseEventDate(b.data_evento)
+
+    if (dateA === null && dateB === null) {
+      return 0
+    }
+    if (dateA === null) {
+      return 1
+    }
+    if (dateB === null) {
+      return -1
+    }
+
     const isAFuture = dateA >= today
     const isBFuture = dateB >= today
     if (isAFuture !== isBFuture) {
       return isAFuture ? -1 : 1
     }
-    return isAFuture ? dateA - dateB : dateB - dateA
+    if (dateA - dateB !== 0) {
+      return isAFuture ? dateA - dateB : dateB - dateA
+    }
+    const timeA = parseTimeMinutes(a.horario)
+    const timeB = parseTimeMinutes(b.horario)
+    return isAFuture ? timeA - timeB : timeB - timeA
   })
 }
 


### PR DESCRIPTION
- CalendarView com grade mensal, navegação por mês e indicadores de dias
- CalendarDay com dots por evento, distinção entre futuros e passados
- CalendarDayModal via portal ao clicar num dia, listando todos os eventos
- CalendarEventItem com layout horizontal, tags, modalidade e localidade
- Toggle de visualização com novo modo Calendário
- FAB de favoritos flutuante no mobile, visível apenas quando há favoritos
- Ordenação de eventos por data e horário
- Acessibilidade: tecla Space, focus trap no modal e focus restaurado
- Animações respeitam prefers-reduced-motion
- Fallback vh para browsers sem suporte a dvh

Closes #81

<img width="1353" height="786" alt="image" src="https://github.com/user-attachments/assets/e35f97e3-6456-4813-8140-7e769de7122f" />
