### PR TITLE
feat: adiciona suporte pwa com service worker e instalação mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,13 @@
 
     <!-- Theme color -->
     <meta name="theme-color" content="#2563eb" />
+
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="CB Eventos" />
+    <meta name="mobile-web-app-capable" content="yes" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,46 @@
+{
+  "name": "Eventos - Cafe Bugado",
+  "short_name": "CB Eventos",
+  "description": "Descubra eventos de tecnologia da comunidade Cafe Bugado",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#2563eb",
+  "orientation": "portrait-primary",
+  "lang": "pt-BR",
+  "categories": ["events", "social", "education"],
+  "icons": [
+    { "src": "/icons/icon-72x72.png", "sizes": "72x72", "type": "image/png" },
+    { "src": "/icons/icon-96x96.png", "sizes": "96x96", "type": "image/png" },
+    { "src": "/icons/icon-128x128.png", "sizes": "128x128", "type": "image/png" },
+    { "src": "/icons/icon-144x144.png", "sizes": "144x144", "type": "image/png" },
+    { "src": "/icons/icon-152x152.png", "sizes": "152x152", "type": "image/png" },
+    { "src": "/icons/icon-192x192.png", "sizes": "192x192", "type": "image/png" },
+    {
+      "src": "/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    { "src": "/icons/icon-384x384.png", "sizes": "384x384", "type": "image/png" },
+    { "src": "/icons/icon-512x512.png", "sizes": "512x512", "type": "image/png" },
+    {
+      "src": "/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Ver Eventos",
+      "url": "/eventos",
+      "icons": [{ "src": "/icons/icon-96x96.png", "sizes": "96x96" }]
+    },
+    {
+      "name": "Home",
+      "url": "/",
+      "icons": [{ "src": "/icons/icon-96x96.png", "sizes": "96x96" }]
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,85 @@
+const CACHE_VERSION = 'v1'
+const STATIC_CACHE = `cb-static-${CACHE_VERSION}`
+const EVENTS_CACHE = `cb-events-${CACHE_VERSION}`
+
+const STATIC_ASSETS = ['/', '/eventos', '/sobre', '/manifest.json', '/favicon.svg']
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(STATIC_CACHE).then((cache) => cache.addAll(STATIC_ASSETS)))
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== STATIC_CACHE && key !== EVENTS_CACHE)
+            .map((key) => caches.delete(key))
+        )
+      )
+  )
+  self.clients.claim()
+})
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+  const url = new URL(request.url)
+
+  if (request.method !== 'GET') {
+    return
+  }
+  if (url.protocol === 'chrome-extension:') {
+    return
+  }
+
+  if (url.href.includes('supabase')) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            const clone = response.clone()
+            caches.open(EVENTS_CACHE).then((cache) => cache.put(request, clone))
+          }
+          return response
+        })
+        .catch(() => caches.match(request))
+    )
+    return
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        if (cached) {
+          return cached
+        }
+        return fetch(request).catch(() => caches.match('/'))
+      })
+    )
+    return
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) {
+        return cached
+      }
+      return fetch(request).then((response) => {
+        if (response.ok) {
+          const clone = response.clone()
+          caches.open(STATIC_CACHE).then((cache) => cache.put(request, clone))
+        }
+        return response
+      })
+    })
+  )
+})
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
+})

--- a/src/components/PwaInstallButton/PwaInstallButton.css
+++ b/src/components/PwaInstallButton/PwaInstallButton.css
@@ -1,0 +1,26 @@
+.pwa-install-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  background-color: var(--primary-blue);
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    opacity 0.2s,
+    box-shadow 0.2s;
+  box-shadow: var(--shadow);
+}
+
+.pwa-install-btn:hover {
+  opacity: 0.85;
+  box-shadow: var(--shadow-hover);
+}
+
+.pwa-install-icon {
+  flex-shrink: 0;
+}

--- a/src/components/PwaInstallButton/PwaInstallButton.jsx
+++ b/src/components/PwaInstallButton/PwaInstallButton.jsx
@@ -1,0 +1,18 @@
+import { Download } from 'lucide-react'
+import { usePwa } from '../../hooks/usePwa.js'
+import './PwaInstallButton.css'
+
+export default function PwaInstallButton({ className = '' }) {
+  const { isInstallable, isInstalled, install } = usePwa()
+
+  if (!isInstallable || isInstalled) {
+    return null
+  }
+
+  return (
+    <button className={`pwa-install-btn ${className}`.trim()} onClick={install}>
+      <Download size={16} className="pwa-install-icon" />
+      Instalar App
+    </button>
+  )
+}

--- a/src/components/PwaUpdateBanner/PwaUpdateBanner.css
+++ b/src/components/PwaUpdateBanner/PwaUpdateBanner.css
@@ -1,0 +1,80 @@
+.pwa-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1.25rem;
+  background-color: var(--surface);
+  border-top: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  animation: pwa-slide-up 0.3s ease-out;
+}
+
+@keyframes pwa-slide-up {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.pwa-banner-icon {
+  color: var(--primary-blue);
+  flex-shrink: 0;
+}
+
+.pwa-banner-text {
+  flex: 1;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.pwa-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.pwa-banner-update-btn {
+  padding: 0.4rem 1rem;
+  background-color: var(--primary-blue);
+  color: #ffffff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.pwa-banner-update-btn:hover {
+  opacity: 0.85;
+}
+
+.pwa-banner-dismiss-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+}
+
+.pwa-banner-dismiss-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}

--- a/src/components/PwaUpdateBanner/PwaUpdateBanner.jsx
+++ b/src/components/PwaUpdateBanner/PwaUpdateBanner.jsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import { X, RefreshCw } from 'lucide-react'
+import { usePwa } from '../../hooks/usePwa.js'
+import './PwaUpdateBanner.css'
+
+export default function PwaUpdateBanner() {
+  const { updateAvailable, applyUpdate } = usePwa()
+  const [dismissed, setDismissed] = useState(false)
+
+  if (!updateAvailable || dismissed) {
+    return null
+  }
+
+  return (
+    <div className="pwa-banner">
+      <RefreshCw className="pwa-banner-icon" size={18} />
+      <span className="pwa-banner-text">Nova versão disponível</span>
+      <div className="pwa-banner-actions">
+        <button className="pwa-banner-update-btn" onClick={applyUpdate}>
+          Atualizar
+        </button>
+        <button
+          className="pwa-banner-dismiss-btn"
+          onClick={() => setDismissed(true)}
+          aria-label="Fechar"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/usePwa.js
+++ b/src/hooks/usePwa.js
@@ -1,0 +1,76 @@
+import { useState, useEffect, useRef } from 'react'
+import {
+  registerServiceWorker,
+  getSwStatus,
+  skipWaiting as swSkipWaiting,
+  isInstalledPwa,
+  canInstall,
+  promptInstall,
+} from '../lib/pwa.js'
+
+export function usePwa() {
+  const [swStatus, setSwStatus] = useState('idle')
+  const [isInstallable, setIsInstallable] = useState(canInstall)
+  const registrationRef = useRef(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const onInstallPrompt = () => {
+      if (isMounted) {
+        setIsInstallable(true)
+      }
+    }
+    window.addEventListener('beforeinstallprompt', onInstallPrompt)
+
+    registerServiceWorker().then((registration) => {
+      if (!isMounted || !registration) {
+        return
+      }
+      registrationRef.current = registration
+      setSwStatus(getSwStatus(registration))
+
+      const trackInstalling = (sw) => {
+        if (!sw) {
+          return
+        }
+        sw.addEventListener('statechange', () => {
+          if (!isMounted) {
+            return
+          }
+          setSwStatus(getSwStatus(registrationRef.current))
+        })
+      }
+
+      registration.addEventListener('updatefound', () => {
+        trackInstalling(registration.installing)
+        if (isMounted) {
+          setSwStatus(getSwStatus(registration))
+        }
+      })
+
+      trackInstalling(registration.installing)
+    })
+
+    return () => {
+      isMounted = false
+      window.removeEventListener('beforeinstallprompt', onInstallPrompt)
+    }
+  }, [])
+
+  const install = () => promptInstall()
+
+  const applyUpdate = () => {
+    swSkipWaiting(registrationRef.current)
+    window.location.reload()
+  }
+
+  return {
+    isInstallable,
+    isInstalled: isInstalledPwa(),
+    swStatus,
+    updateAvailable: swStatus === 'waiting',
+    install,
+    applyUpdate,
+  }
+}

--- a/src/lib/pwa.js
+++ b/src/lib/pwa.js
@@ -1,0 +1,66 @@
+let deferredPrompt = null
+let registrationPromise = null
+
+export function registerServiceWorker() {
+  if (!('serviceWorker' in navigator)) {
+    return Promise.resolve(null)
+  }
+  if (!registrationPromise) {
+    registrationPromise = navigator.serviceWorker
+      .register('/sw.js', { scope: '/' })
+      .catch(() => null)
+  }
+  return registrationPromise
+}
+
+export function getSwStatus(registration) {
+  if (!('serviceWorker' in navigator)) {
+    return 'unsupported'
+  }
+  if (!registration) {
+    return 'idle'
+  }
+  if (registration.installing) {
+    return 'installing'
+  }
+  if (registration.waiting) {
+    return 'waiting'
+  }
+  if (registration.active) {
+    return 'active'
+  }
+  return 'idle'
+}
+
+export function skipWaiting(registration) {
+  if (registration?.waiting) {
+    registration.waiting.postMessage({ type: 'SKIP_WAITING' })
+  }
+}
+
+export function isInstalledPwa() {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true
+  )
+}
+
+export function canInstall() {
+  return deferredPrompt !== null
+}
+
+export async function promptInstall() {
+  if (!deferredPrompt) {
+    return null
+  }
+  deferredPrompt.prompt()
+  const { outcome } = await deferredPrompt.userChoice
+  deferredPrompt = null
+  return outcome
+}
+
+export function captureInstallPrompt() {
+  window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault()
+    deferredPrompt = e
+  })
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,6 +10,11 @@ import ErrorBoundary from './components/ErrorBoundary.jsx'
 import { ThemeProvider } from './context/ThemeProvider.jsx'
 import ScrollToTop from './components/ScrollToTop/ScrollToTop.jsx'
 import PageLoader from './components/PageLoader.jsx'
+import PwaUpdateBanner from './components/PwaUpdateBanner/PwaUpdateBanner.jsx'
+import { captureInstallPrompt, registerServiceWorker } from './lib/pwa.js'
+
+captureInstallPrompt()
+registerServiceWorker()
 
 // Páginas carregadas via lazy (code splitting por rota)
 const Home = lazy(() => import('./pages/Home.jsx'))
@@ -54,6 +59,7 @@ createRoot(document.getElementById('root')).render(
             </Routes>
           </Suspense>
           <ScrollToTop />
+          <PwaUpdateBanner />
           <Analytics />
           <SpeedInsights />
         </BrowserRouter>


### PR DESCRIPTION
- registra service worker com cache-first para assets e network-first para api supabase
- cria manifest.json com ícones, shortcuts e configuração standalone
- adiciona utilitários em pwa.js e hook usePwa para gerenciar estado da pwa
- implementa PwaUpdateBanner para notificar novas versões disponíveis
- implementa PwaInstallButton reutilizável para prompt de instalação
- configura meta tags apple/mobile no index.html para suporte ios
- estrutura pronta para adição futura de push notifications

Closes #75