### PR TITLE
feat: adiciona banner de instalação do pwa

### DIFF
--- a/src/components/PwaInstallBanner/PwaInstallBanner.css
+++ b/src/components/PwaInstallBanner/PwaInstallBanner.css
@@ -1,0 +1,164 @@
+.pwa-install-banner {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1100;
+  width: min(420px, calc(100vw - 2rem));
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-hover);
+  padding: 1.1rem 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  animation: pwa-install-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes pwa-install-pop {
+  from {
+    transform: translateX(-50%) translateY(30px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
+  }
+}
+
+/* ---- Header ---- */
+.pwa-install-banner-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.pwa-install-banner-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.pwa-install-banner-icon {
+  color: var(--primary-blue);
+  flex-shrink: 0;
+}
+
+.pwa-install-close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+}
+
+.pwa-install-close-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
+/* ---- Description ---- */
+.pwa-install-banner-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.45;
+  margin: 0;
+}
+
+/* ---- iOS instructions ---- */
+.pwa-install-instructions {
+  background-color: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem 0.9rem;
+}
+
+.pwa-install-instructions-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.5rem;
+}
+
+.pwa-install-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.pwa-install-steps li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.pwa-install-step-icon {
+  display: flex;
+  align-items: center;
+  color: var(--primary-blue);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+/* ---- Install button ---- */
+.pwa-install-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background-color: var(--primary-blue);
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.pwa-install-action-btn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.pwa-install-action-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ---- Never show link ---- */
+.pwa-install-never-btn {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-align: center;
+  text-decoration: underline;
+  transition: color 0.2s;
+}
+
+.pwa-install-never-btn:hover {
+  color: var(--text-primary);
+}

--- a/src/components/PwaInstallBanner/PwaInstallBanner.jsx
+++ b/src/components/PwaInstallBanner/PwaInstallBanner.jsx
@@ -1,0 +1,126 @@
+import { useState, useEffect, useRef } from 'react'
+import { X, Download, Share, Plus, Smartphone } from 'lucide-react'
+import { usePwa } from '../../hooks/usePwa.js'
+import './PwaInstallBanner.css'
+
+const STORAGE_KEY = 'pwa-install-banner-dismissed'
+
+function detectPlatform() {
+  const ua = navigator.userAgent
+  const isIOS = /iPad|iPhone|iPod/.test(ua) && !window.MSStream
+  const isSafari = /^((?!chrome|android).)*safari/i.test(ua)
+  return { isIOS, isIOSSafari: isIOS && isSafari }
+}
+
+function IOSInstructions() {
+  return (
+    <div className="pwa-install-instructions">
+      <p className="pwa-install-instructions-title">Para instalar no iPhone / iPad:</p>
+      <ol className="pwa-install-steps">
+        <li>
+          <span className="pwa-install-step-icon">
+            <Share size={15} />
+          </span>
+          Toque no botão <strong>Compartilhar</strong> na barra do Safari
+        </li>
+        <li>
+          <span className="pwa-install-step-icon">
+            <Plus size={15} />
+          </span>
+          Role para baixo e toque em <strong>"Adicionar à Tela de Início"</strong>
+        </li>
+        <li>
+          <span className="pwa-install-step-icon">
+            <Smartphone size={15} />
+          </span>
+          Toque em <strong>Adicionar</strong> para confirmar
+        </li>
+      </ol>
+    </div>
+  )
+}
+
+const { isIOSSafari } = detectPlatform()
+
+export default function PwaInstallBanner() {
+  const { isInstallable, isInstalled, install } = usePwa()
+  const [visible, setVisible] = useState(false)
+  const [installing, setInstalling] = useState(false)
+  const timerRef = useRef(null)
+  const shownRef = useRef(false)
+
+  // canShow: Android/Desktop quando isInstallable vira true; iOS Safari sempre
+  const canShow = (isInstallable || isIOSSafari) && !isInstalled
+
+  useEffect(() => {
+    // Já agendou ou já mostrou — não repetir
+    if (shownRef.current) {
+      return
+    }
+    if (!canShow) {
+      return
+    }
+    if (localStorage.getItem(STORAGE_KEY) === 'true') {
+      return
+    }
+
+    shownRef.current = true
+    timerRef.current = setTimeout(() => setVisible(true), 3000)
+
+    return () => clearTimeout(timerRef.current)
+  }, [canShow])
+
+  function handleDismiss() {
+    setVisible(false)
+  }
+
+  function handleNeverShow() {
+    localStorage.setItem(STORAGE_KEY, 'true')
+    setVisible(false)
+  }
+
+  async function handleInstall() {
+    setInstalling(true)
+    const outcome = await install()
+    setInstalling(false)
+    if (outcome === 'accepted') {
+      setVisible(false)
+    }
+  }
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <div className="pwa-install-banner" role="dialog" aria-label="Instalar aplicativo">
+      <div className="pwa-install-banner-header">
+        <div className="pwa-install-banner-title">
+          <Smartphone size={18} className="pwa-install-banner-icon" />
+          <span>Instale o app no seu dispositivo!</span>
+        </div>
+        <button className="pwa-install-close-btn" onClick={handleDismiss} aria-label="Fechar">
+          <X size={16} />
+        </button>
+      </div>
+
+      <p className="pwa-install-banner-desc">
+        Acesse eventos, agenda e novidades direto da tela inicial — sem precisar abrir o navegador.
+        Funciona offline também!
+      </p>
+
+      {isIOSSafari ? (
+        <IOSInstructions />
+      ) : (
+        <button className="pwa-install-action-btn" onClick={handleInstall} disabled={installing}>
+          <Download size={16} />
+          {installing ? 'Aguarde…' : 'Instalar agora'}
+        </button>
+      )}
+
+      <button className="pwa-install-never-btn" onClick={handleNeverShow}>
+        Não mostrar novamente
+      </button>
+    </div>
+  )
+}

--- a/src/hooks/usePwa.js
+++ b/src/hooks/usePwa.js
@@ -11,6 +11,7 @@ import {
 export function usePwa() {
   const [swStatus, setSwStatus] = useState('idle')
   const [isInstallable, setIsInstallable] = useState(canInstall)
+  const [installed, setInstalled] = useState(isInstalledPwa)
   const registrationRef = useRef(null)
 
   useEffect(() => {
@@ -21,7 +22,16 @@ export function usePwa() {
         setIsInstallable(true)
       }
     }
+
+    const onAppInstalled = () => {
+      if (isMounted) {
+        setInstalled(true)
+        setIsInstallable(false)
+      }
+    }
+
     window.addEventListener('beforeinstallprompt', onInstallPrompt)
+    window.addEventListener('appinstalled', onAppInstalled)
 
     registerServiceWorker().then((registration) => {
       if (!isMounted || !registration) {
@@ -55,6 +65,7 @@ export function usePwa() {
     return () => {
       isMounted = false
       window.removeEventListener('beforeinstallprompt', onInstallPrompt)
+      window.removeEventListener('appinstalled', onAppInstalled)
     }
   }, [])
 
@@ -67,7 +78,7 @@ export function usePwa() {
 
   return {
     isInstallable,
-    isInstalled: isInstalledPwa(),
+    isInstalled: installed,
     swStatus,
     updateAvailable: swStatus === 'waiting',
     install,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,7 @@ import { ThemeProvider } from './context/ThemeProvider.jsx'
 import ScrollToTop from './components/ScrollToTop/ScrollToTop.jsx'
 import PageLoader from './components/PageLoader.jsx'
 import PwaUpdateBanner from './components/PwaUpdateBanner/PwaUpdateBanner.jsx'
+import PwaInstallBanner from './components/PwaInstallBanner/PwaInstallBanner.jsx'
 import { captureInstallPrompt, registerServiceWorker } from './lib/pwa.js'
 
 captureInstallPrompt()
@@ -60,6 +61,7 @@ createRoot(document.getElementById('root')).render(
           </Suspense>
           <ScrollToTop />
           <PwaUpdateBanner />
+          <PwaInstallBanner />
           <Analytics />
           <SpeedInsights />
         </BrowserRouter>


### PR DESCRIPTION
exibe banner informando sobre a disponibilidade do app instalável, com botão direto no android/desktop e instruções passo a passo no ios safari. o banner aparece 3 segundos após o carregamento, não exibe se o app já estiver instalado e respeita a preferência do usuário via localstorage.

