### PR TITLE
refactor: organizado os skeletons inline para componentes proprios

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,31 +4,31 @@
 version: 2
 updates:
   # Dependências npm/pnpm
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: 'weekly'
+      day: 'monday'
     open-pull-requests-limit: 10
-    target-branch: "developer"
+    target-branch: 'developer'
     labels:
-      - "dependencies"
-      - "security"
+      - 'dependencies'
+      - 'security'
     commit-message:
-      prefix: "chore(deps):"
+      prefix: 'chore(deps):'
     reviewers:
-      - "cafebugado"
+      - 'cafebugado'
 
   # GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: 'weekly'
+      day: 'monday'
     open-pull-requests-limit: 5
-    target-branch: "developer"
+    target-branch: 'developer'
     labels:
-      - "ci"
-      - "dependencies"
+      - 'ci'
+      - 'dependencies'
     commit-message:
-      prefix: "chore(ci):"
+      prefix: 'chore(ci):'

--- a/api/og.ts
+++ b/api/og.ts
@@ -96,8 +96,7 @@ function generateHtml({
   type?: string
   publishedTime?: string
 }): string {
-  const fullTitle =
-    title !== SITE_NAME ? `${escapeHtml(title)} | ${SITE_NAME}` : SITE_NAME
+  const fullTitle = title !== SITE_NAME ? `${escapeHtml(title)} | ${SITE_NAME}` : SITE_NAME
   const safeTitle = escapeHtml(title)
   const safeDescription = escapeHtml(description)
 

--- a/index.html
+++ b/index.html
@@ -5,13 +5,19 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Eventos - Comunidade Cafe Bugado</title>
-    <meta name="description" content="Descubra os melhores eventos de tecnologia. Meetups, workshops, hackathons e conferencias reunidos em um so lugar pela comunidade." />
+    <meta
+      name="description"
+      content="Descubra os melhores eventos de tecnologia. Meetups, workshops, hackathons e conferencias reunidos em um so lugar pela comunidade."
+    />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://eventos.cafebugado.com.br/" />
     <meta property="og:title" content="Eventos - Comunidade Cafe Bugado" />
-    <meta property="og:description" content="Descubra os melhores eventos de tecnologia. Meetups, workshops, hackathons e conferencias reunidos em um so lugar pela comunidade." />
+    <meta
+      property="og:description"
+      content="Descubra os melhores eventos de tecnologia. Meetups, workshops, hackathons e conferencias reunidos em um so lugar pela comunidade."
+    />
     <meta property="og:image" content="https://eventos.cafebugado.com.br/eventos.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -23,7 +29,10 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://eventos.cafebugado.com.br/" />
     <meta name="twitter:title" content="Eventos - Comunidade Cafe Bugado" />
-    <meta name="twitter:description" content="Descubra os melhores eventos de tecnologia. Meetups, workshops, hackathons e conferencias reunidos em um so lugar pela comunidade." />
+    <meta
+      name="twitter:description"
+      content="Descubra os melhores eventos de tecnologia. Meetups, workshops, hackathons e conferencias reunidos em um so lugar pela comunidade."
+    />
     <meta name="twitter:image" content="https://eventos.cafebugado.com.br/eventos.png" />
 
     <!-- Google Search Console verification -->

--- a/src/components/ContributorsGrid.jsx
+++ b/src/components/ContributorsGrid.jsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react'
 import { Github, Linkedin, ExternalLink } from 'lucide-react'
 import { getContributors } from '../services/contributorService'
+import ContributorSkeleton from './skeletons/ContributorsSkeleton'
 function ContributorsGrid() {
   const [contributors, setContributors] = useState([])
   const [loadingContributors, setLoadingContributors] = useState(true)
-
   useEffect(() => {
     async function loadContributors() {
       try {
@@ -33,11 +33,7 @@ function ContributorsGrid() {
         <div className="contributors-loading">
           <div className="contributors-grid">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="contributor-card-skeleton">
-                <div className="skeleton-avatar"></div>
-                <div className="skeleton-name"></div>
-                <div className="skeleton-links"></div>
-              </div>
+              <ContributorSkeleton key={`contributor-skeleton-${i}`} />
             ))}
           </div>
         </div>

--- a/src/components/EventRecommendations.jsx
+++ b/src/components/EventRecommendations.jsx
@@ -5,6 +5,7 @@ import { getRecommendedEvents } from '../services/eventService'
 import EventCard from './EventCard'
 import './EventRecommendations.css'
 import { parseEventDate } from '../utils/eventDate'
+import SkeletonRecommendations from './skeletons/SkeletonRecommendations'
 
 function EventRecommendations({ currentEvent, currentEventTags }) {
   const [recommendations, setRecommendations] = useState([])
@@ -93,14 +94,7 @@ function EventRecommendations({ currentEvent, currentEventTags }) {
         <div className="event-recs-grid">
           {loading
             ? Array.from({ length: 3 }).map((_, i) => (
-                <div key={`rec-skeleton-${i}`} className="event-recs-skeleton">
-                  <div className="event-recs-skeleton-image" />
-                  <div className="event-recs-skeleton-content">
-                    <div className="event-recs-skeleton-title" />
-                    <div className="event-recs-skeleton-text" />
-                    <div className="event-recs-skeleton-text short" />
-                  </div>
-                </div>
+                <SkeletonRecommendations key={`skeleton-${i}`} />
               ))
             : recommendations.map((rec) => (
                 <EventCard key={rec.id} event={rec} tags={rec.tags || []} />

--- a/src/components/UpcomingEvents.jsx
+++ b/src/components/UpcomingEvents.jsx
@@ -3,6 +3,7 @@ import { ArrowRight } from 'lucide-react'
 import { useUpcomingEvents } from '../hooks/useEvents'
 import EventCard from './EventCard'
 import './UpcomingEvents.css'
+import EventCardSkeleton from './skeletons/EventCardSkeleton'
 
 function UpcomingEvents() {
   const { events, loading, error } = useUpcomingEvents(3)
@@ -23,14 +24,7 @@ function UpcomingEvents() {
         {loading ? (
           <div className="upcoming-grid">
             {Array.from({ length: 3 }).map((_, i) => (
-              <div key={`skeleton-${i}`} className="upcoming-skeleton">
-                <div className="upcoming-skeleton-image" />
-                <div className="upcoming-skeleton-content">
-                  <div className="upcoming-skeleton-title" />
-                  <div className="upcoming-skeleton-text" />
-                  <div className="upcoming-skeleton-text short" />
-                </div>
-              </div>
+              <EventCardSkeleton key={`skeleton-${i}`} />
             ))}
           </div>
         ) : (

--- a/src/components/skeletons/ContributorsSkeleton.jsx
+++ b/src/components/skeletons/ContributorsSkeleton.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+function ContributorsSkeleton() {
+  return (
+    <div className="contributor-card-skeleton">
+      <div className="skeleton-avatar"></div>
+      <div className="skeleton-name"></div>
+      <div className="skeleton-links"></div>
+    </div>
+  )
+}
+export default ContributorsSkeleton

--- a/src/components/skeletons/EventCardSkeleton.jsx
+++ b/src/components/skeletons/EventCardSkeleton.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+function EventCardSkeleton() {
+  return (
+    <div className="skeleton-card">
+      <div className="skeleton-image" />
+      <div className="skeleton-content">
+        <div className="skeleton-title" />
+        <div className="skeleton-text" />
+        <div className="skeleton-text" />
+        <div className="skeleton-text short" />
+        <div className="skeleton-info-grid">
+          <div className="skeleton-info" />
+          <div className="skeleton-info" />
+          <div className="skeleton-info" />
+        </div>
+        <div className="skeleton-button" />
+      </div>
+    </div>
+  )
+}
+export default EventCardSkeleton

--- a/src/components/skeletons/EventDetailSkeleton.jsx
+++ b/src/components/skeletons/EventDetailSkeleton.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+function EventDetailSkeleton() {
+  return (
+    <div className="event-details-page">
+      <main className="details-main">
+        <div className="details-container">
+          <div className="skeleton-back-button"></div>
+          <div
+            className="skeleton-detail-card"
+            role="status"
+            aria-busy="true"
+            aria-label="Carregando detalhes do evento"
+          >
+            <div className="skeleton-detail-image"></div>
+            <div className="skeleton-detail-content">
+              <div className="skeleton-detail-title"></div>
+              <div className="skeleton-detail-description">
+                <div className="skeleton-text"></div>
+                <div className="skeleton-text"></div>
+                <div className="skeleton-text"></div>
+                <div className="skeleton-text short"></div>
+              </div>
+              <div className="skeleton-detail-info-grid">
+                <div className="skeleton-info-card"></div>
+                <div className="skeleton-info-card"></div>
+                <div className="skeleton-info-card"></div>
+              </div>
+              <div className="skeleton-button large"></div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}
+export default EventDetailSkeleton

--- a/src/components/skeletons/SkeletonRecommendations.jsx
+++ b/src/components/skeletons/SkeletonRecommendations.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+function SkeletonRecommendations() {
+  return (
+    <div className="event-recs-skeleton">
+      <div className="event-recs-skeleton-image" />
+      <div className="event-recs-skeleton-content">
+        <div className="event-recs-skeleton-title" />
+        <div className="event-recs-skeleton-text" />
+        <div className="event-recs-skeleton-text short" />
+      </div>
+    </div>
+  )
+}
+export default SkeletonRecommendations

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -14,6 +14,7 @@ import BgEventos from '../assets/eventos.png'
 import './EventDetails.css'
 import { FavouriteEventButton } from '../components/FavouriteEventButton'
 import { isEventPast } from '../utils/eventDate'
+import EventDetailSkeleton from '../components/skeletons/EventDetailSkeleton'
 
 function EventDetails() {
   const { id } = useParams()
@@ -104,38 +105,7 @@ function EventDetails() {
   }
 
   if (loading) {
-    return (
-      <div className="event-details-page">
-        <main className="details-main">
-          <div className="details-container">
-            <div className="skeleton-back-button"></div>
-            <div
-              className="skeleton-detail-card"
-              role="status"
-              aria-busy="true"
-              aria-label="Carregando detalhes do evento"
-            >
-              <div className="skeleton-detail-image"></div>
-              <div className="skeleton-detail-content">
-                <div className="skeleton-detail-title"></div>
-                <div className="skeleton-detail-description">
-                  <div className="skeleton-text"></div>
-                  <div className="skeleton-text"></div>
-                  <div className="skeleton-text"></div>
-                  <div className="skeleton-text short"></div>
-                </div>
-                <div className="skeleton-detail-info-grid">
-                  <div className="skeleton-info-card"></div>
-                  <div className="skeleton-info-card"></div>
-                  <div className="skeleton-info-card"></div>
-                </div>
-                <div className="skeleton-button large"></div>
-              </div>
-            </div>
-          </div>
-        </main>
-      </div>
-    )
+    return <EventDetailSkeleton />
   }
 
   if (error) {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -8,16 +8,13 @@ import './Home.css'
 import { useEffect } from 'react'
 
 function Home() {
+  useEffect(() => {
+    const stored = localStorage.getItem('favourites')
+    if (!stored) {
+      localStorage.setItem('favourites', '[]')
+    }
+  }, [])
 
-  useEffect(()=>{
-      const stored = localStorage.getItem('favourites')
-      if (!stored) {
-        localStorage.setItem("favourites",'[]')
-      } 
-  },[])
-
-
-  
   return (
     <Layout>
       <SEOHead


### PR DESCRIPTION
## Refactor: Criado novos componentes para skeletons,  retirando-os de inline e transformando em componentes proprios.

Skeletons de cards de eventos e contribuidores foram afetados, removendo inlines e  usando a importação do componente.

- [ ] `fix` — Correção de bug
- [ ] `feat` — Nova funcionalidade
- [x] `refactor` — Refatoração sem mudança de comportamento
- [x] `style` — Ajustes de estilo/CSS (sem lógica)
- [ ] `test` — Adição ou correção de testes
- [ ] `docs` — Documentação
- [ ] `chore` — Manutenção, dependências, config

Closes #10


## Como testar


1. Checkout nesta branch: `git checkout skeletons-inline-fix`
2. Instalar dependências: `pnpm install`
3. Subir ambiente local: `pnpm dev`
4. Navegar até:  A:\Cafe bugado\eventos/src/components/skeletons>
5. Uma pasta com os arquivos de skeletons e tambem todos sendo importados em:
-ContributorsGrid.jsx
-EventRecomendations.jsx
-UpcomingEvents.jsx
-EventsDetails.jsx


## Observações

Os testes que estão falhando no CI não são relacionados as alterações desse PR. Os mesmos erros já existem na branch developer