### PR TITLE
Developer

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -88,6 +88,9 @@ self.addEventListener('fetch', (event) => {
 })
 
 self.addEventListener('message', (event) => {
+  if (event.origin !== self.location.origin) {
+    return
+  }
   if (event.data?.type === 'SKIP_WAITING') {
     self.skipWaiting()
   }

--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -367,10 +367,10 @@ function Dashboard() {
     (evento) => {
       const eventUrl = `${window.location.origin}/eventos/${evento.id}`
       const message =
-        `Confira o evento "${evento.nome}" da Comunidade Cafe Bugado!\n\n` +
+        `Confira o evento "${evento.nome}"!\n\n` +
         `📅 ${evento.data_evento}${evento.horario ? ` às ${evento.horario}` : ''}\n\n` +
         `🔗 ${eventUrl}\n\n` +
-        `Siga nossa comunidade:\n` +
+        `Divulgado pela Comunidade Cafe Bugado:\n` +
         `Instagram: @comunidadecafebugado`
       navigator.clipboard
         .writeText(message)


### PR DESCRIPTION
remove "da Comunidade Cafe Bugado" da mensagem de cópia de link, evitando dar a entender que o evento pertence à comunidade
substitui por "Divulgado pela Comunidade Cafe Bugado" para deixar claro o papel da comunidade como divulgadora
adiciona verificação de event.origin no postMessage handler do sw para aceitar apenas mensagens do próprio domínio (CWE-940)