### PR TITLE
Fix/input validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <meta name="twitter:image" content="https://eventos.cafebugado.com.br/eventos.png" />
 
     <!-- Google Search Console verification -->
-    <meta name="google-site-verification" content="egYLb8_gEz8qR4" />
+    <meta name="google-site-verification" content="egYLb8_gEz8qR43udpDqq5yhq3sn5ucIMBEwq-nA7SM" />
 
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/admin/Dashboard.jsx
+++ b/src/admin/Dashboard.jsx
@@ -522,10 +522,11 @@ function Dashboard() {
   }
 
   const handleImagePreview = (e) => {
-    const isURLValid = validateURL(e.target.value)
+    const val = e.target.value
+    const isURLValid = validateURL(val)
 
     if (isURLValid && !imageFile) {
-      const urlObject = new URL(e.target.value)
+      const urlObject = new URL(val)
       setImagePreview(urlObject)
     }
   }

--- a/src/utils/validateURL.js
+++ b/src/utils/validateURL.js
@@ -1,6 +1,24 @@
 export const validateURL = (value) => {
+  /**
+   *  Expressão para validação de URL baseada em RFC 1035 / RFC 6570
+   *
+   *  Estrutura: <protocolo>://<subdomíno.domínio | domínio>/<file_path | resource path>
+   *
+   *  Para manter os requisitos de segurança, essa expressão regular permite apenas arquivos
+   *  com extensão de arquivos de imagem permitidos e possui uma exceção para o
+   *  domínio https://encrypted-tbn0.gstatic.com/images
+   *
+   *  Estrutura da expressão:
+   *  - Schema/Procolo HTTP | HTTPS: ^(http[s]?:\/{2})
+   *  - Domínio: ((?!.{254,})(?:(?!-)(?:xn--[A-Za-z0-9-]{1,59}|(?!xn--)[A-Za-z0-9-]{1,63})(?<!-)\.)+(?:xn--[A-Za-z0-9-]{1,59}|[A-Za-z]{2,63}))
+   *  - Recurso (Path): ((\/)(images\?q=\w+:[A-Za-z0-9&-]+)
+   *  - Arquivo no padrão da CDN do Google: ((\/)((images\?q=\w+:[A-Za-z0-9&-]+)
+   *  - Ou extensão do arquivo de image: |(([A-Za-z0-9-_,:./=]{1,59}))+(\.)(png|jpg|jpeg|webp)(\?[wh]=[0-9]{2,4})?))$
+   *
+   */
+
   const allowedProtocolsRegExp =
-    /^(http[s]?:\/{2})((?!.{254,})(?:(?!-)(?:xn--[A-Za-z0-9-]{1,59}|(?!xn--)[A-Za-z0-9-]{1,63})(?<!-)\.)+(?:xn--[A-Za-z0-9-]{1,59}|[A-Za-z]{2,63}))(\/)(([A-Za-z0-9-]{1,59})(\.png|jpg|jpeg|webp)|(images\?q=\w+:[A-Za-z0-9&_-]+))$/
+    /^((http[s]?:\/{2})((?!.{254,})(?:(?!-)(?:xn--[A-Za-z0-9-]{1,59}|(?!xn--)[A-Za-z0-9-]{1,63})(?<!-)\.)+(?:xn--[A-Za-z0-9-]{1,59}|[A-Za-z]{2,63})))((\/)((images\?q=\w+:[A-Za-z0-9&-]+)|(([A-Za-z0-9-_,:./=]{1,59}))+(\.)(png|jpg|jpeg|webp)(\?[wh]=[0-9]{2,4})?))$/
 
   const isURLValid = allowedProtocolsRegExp.test(value)
 


### PR DESCRIPTION
## Descrição

<!-- Descreva de forma clara e objetiva o que este PR faz. Ex: "Corrige o bug onde a imagem do EventCard não cobria o card completamente" -->

Corrige os efeitos colaterais do fix de segurança implementado no PR #339, onde a expressão regular de filtragem considerava URLs com padrões mais fechados.

## Tipo de mudança

<!-- Marque com [x] os tipos aplicáveis -->

- [x] `fix` — Correção de bug
- [ ] `feat` — Nova funcionalidade
- [ ] `refactor` — Refatoração sem mudança de comportamento
- [ ] `style` — Ajustes de estilo/CSS (sem lógica)
- [ ] `test` — Adição ou correção de testes
- [ ] `docs` — Documentação
- [ ] `chore` — Manutenção, dependências, config

## Issue relacionada

<!-- Referencia a issue que este PR resolve. Ex: Closes #42 -->

Closes #299

## Checklist — antes de solicitar review

### Qualidade de código

- [x] O código segue os padrões do projeto (ESLint passa: `pnpm lint`)
- [x] A formatação está correta (Prettier passa: `pnpm format:check`)
- [x] Não há `console.log` ou código de debug esquecido
- [x] Não há secrets ou variáveis de ambiente hardcoded

### Testes

- [x] Os testes existentes continuam passando (`pnpm test:run`)
- [x] Adicionei testes para a mudança implementada (quando aplicável)
- [x] A cobertura de testes não regrediu (`pnpm test:coverage`)

### Build

- [x] O build de produção passa sem erros (`pnpm build`)

### Componentes e UI (se aplicável)

- [ ] Testei nas variantes aplicáveis do `EventCard` (`variant="compact"` e `variant="full"`)
- [ ] Verifiquei responsividade (mobile, tablet, desktop)
- [ ] As variáveis CSS do projeto foram usadas (`--primary-blue`, `--surface`, `--background`, etc.)
- [ ] Não quebrei estilos de outras telas

### Dados e serviços (se aplicável)

- [ ] Chamadas ao Supabase usam `withRetry` de `apiClient.js`
- [ ] Datas estão no formato correto (`DD/MM/YYYY` para exibição, `YYYY-MM-DD` para input date nativo)
- [ ] Imports circulares foram evitados (usar import dinâmico quando necessário)

## Como testar

<!-- Passo a passo para o reviewer reproduzir e validar a mudança -->

1. Checkout nesta branch: `git checkout <nome-da-branch>`
2. Instalar dependências: `pnpm install`
3. Subir ambiente local: `pnpm dev`
4. Navegar até: `/admin`
5. Ao cadastrar um evento, a URL deverá gerar um preview normalmente com URLs válidas.

URLs utilizadas para amostragem: 

```
http://www.ietf.org/rfc/rfc2396.png
https://2026.cryptorave.org/img/crlogo.webp
https://d3m889aznlr23d.cloudfront.net/img/events/id/459/459324039/assets/f3c5fba735f9a81f36458392f07adaf4.Sao-Paulo.png
https://d3m889aznlr23d.cloudfront.net/img/events/id/459/459097429/assets/59fb8969a352188083b05cf9b9bf18e5.Splash-Reg-Form-1024x1024.png
https://images.sympla.com.br/69de520589263-xs.jpg
https://images.sympla.com.br/69c5fad1cab74-xs.png
https://images.even3.com/iHEXbBDGb8sNg_g7qAu5an9md-M=/1100x440/smart/https://static.even3.com/banner/PySulLondrina.a3cbb256d59e4db5aa58.png
https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTTYm766u0IiFmYiM5rz7mGBhPL5XHraVDgow&s
https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcQTKKJTdjRwGAuxmWfykekIU722p2qN4Y33qpYnbPx7BbxJuFtZ
https://secure.meetupstatic.com/photos/event/5/f/2/3/event_524124355.jpeg?w=128
https://secure.meetupstatic.com/photos/event/4/a/1/a/highres_533718970.webp?w=640
https://secure.meetupstatic.com/next/images/fallbacks/redesign/group-cover-4-wide.webp?w=640
https://services.google.com/fh/files/events/bwai26_logo_lockup_stacked_gcl26.jpg
```

## Screenshots / Gravação (se aplicável)

<!-- Antes e depois para mudanças visuais. Arraste as imagens aqui ou cole do clipboard -->

| Antes | Depois |
| ----- | ------ |
|       |        |

## Contexto adicional

<!-- Qualquer informação extra que ajude o reviewer: decisões de design, trade-offs, limitações conhecidas, débito técnico gerado -->
