### PR TITLE
fix(api): reconhece falhas de rede do node no retry automático

### DIFF
--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -15,6 +15,24 @@ function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+// Códigos de erro do undici (fetch nativo do Node, usado nas funções
+// serverless da Vercel onde as páginas force-dynamic rodam) pra falha de
+// conexão/timeout — bem diferentes das mensagens de erro do fetch do
+// browser ('Failed to fetch', 'NetworkError') que os checks abaixo já
+// cobriam. Sem isso, qualquer instabilidade de rede no servidor nunca era
+// retentada: a primeira tentativa falhava e o erro subia na hora.
+const NODE_NETWORK_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+])
+
 /**
  * Executa uma função async com timeout e retry automático.
  * Retry só ocorre para erros de rede/timeout, não para erros de negócio.
@@ -25,20 +43,28 @@ export async function withRetry(fn, options = {}) {
   let lastError
 
   for (let attempt = 0; attempt <= retries; attempt++) {
+    let timeoutId
     try {
       const result = await Promise.race([
         fn(),
-        new Promise((_, reject) => setTimeout(() => reject(new TimeoutError(timeout)), timeout)),
+        new Promise((_, reject) => {
+          timeoutId = setTimeout(() => reject(new TimeoutError(timeout)), timeout)
+        }),
       ])
+      clearTimeout(timeoutId)
       return result
     } catch (error) {
+      clearTimeout(timeoutId)
       lastError = error
 
       const isRetryable =
         error instanceof TimeoutError ||
         error?.message?.includes('Failed to fetch') ||
         error?.message?.includes('NetworkError') ||
-        error?.code === 'NETWORK_ERROR'
+        error?.message?.includes('fetch failed') ||
+        error?.code === 'NETWORK_ERROR' ||
+        NODE_NETWORK_ERROR_CODES.has(error?.code) ||
+        NODE_NETWORK_ERROR_CODES.has(error?.cause?.code)
 
       if (!isRetryable || attempt >= retries) {
         break

--- a/src/lib/apiClient.test.js
+++ b/src/lib/apiClient.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { withRetry } from './apiClient'
+
+vi.mock('./sentry.js', () => ({
+  captureError: vi.fn(),
+}))
+
+describe('withRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retenta e resolve quando o Node lança TypeError("fetch failed") com cause.code de rede (undici)', async () => {
+    const networkError = Object.assign(new TypeError('fetch failed'), {
+      cause: { code: 'ECONNREFUSED' },
+    })
+    const fn = vi.fn().mockRejectedValueOnce(networkError).mockResolvedValueOnce('ok')
+
+    const promise = withRetry(fn, { context: 'test' })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('retenta quando error.code é um código de rede do undici (ex.: timeout de conexão)', async () => {
+    const timeoutError = Object.assign(new Error('connect timeout'), {
+      code: 'UND_ERR_CONNECT_TIMEOUT',
+    })
+    const fn = vi.fn().mockRejectedValueOnce(timeoutError).mockResolvedValueOnce('ok')
+
+    const promise = withRetry(fn, { context: 'test' })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('continua retentando mensagens de erro de rede do browser (Failed to fetch / NetworkError)', async () => {
+    const browserError = new TypeError('Failed to fetch')
+    const fn = vi.fn().mockRejectedValueOnce(browserError).mockResolvedValueOnce('ok')
+
+    const promise = withRetry(fn, { context: 'test' })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('não retenta erros de negócio (ex.: 404 respondido pela API)', async () => {
+    const businessError = Object.assign(new Error('GET /events respondeu 404'), { status: 404 })
+    const fn = vi.fn().mockRejectedValue(businessError)
+
+    const promise = withRetry(fn, { context: 'test' })
+    const expectation = expect(promise).rejects.toBe(businessError)
+    await vi.runAllTimersAsync()
+
+    await expectation
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('desiste depois do número máximo de tentativas mesmo com erro retentável', async () => {
+    const networkError = Object.assign(new TypeError('fetch failed'), {
+      cause: { code: 'ETIMEDOUT' },
+    })
+    const fn = vi.fn().mockRejectedValue(networkError)
+
+    const promise = withRetry(fn, { context: 'test', retries: 2 })
+    const expectation = expect(promise).rejects.toBe(networkError)
+    await vi.runAllTimersAsync()
+
+    await expectation
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+})


### PR DESCRIPTION
O retry só reconhecia mensagens de erro do fetch do browser ('Failed to fetch', 'NetworkError'), mas as páginas force-dynamic rodam em funções serverless da Vercel, onde o fetch do Node lança erros bem diferentes (TypeError 'fetch failed' com cause.code tipo ECONNREFUSED/ ETIMEDOUT/UND_ERR_*). Sem reconhecer esse shape, qualquer instabilidade de rede no servidor nunca tinha uma segunda chance — falhava na primeira tentativa e o erro já subia pra página. Também corrige o timer de timeout de cada tentativa, que nunca era limpo e ficava pendente rejeitando uma promise órfã minutos depois.

## Descrição

<!-- Descreva de forma clara e objetiva o que este PR faz. Ex: "Corrige o bug onde a imagem do EventCard não cobria o card completamente" -->

## Tipo de mudança

<!-- Marque com [x] os tipos aplicáveis -->

- [ ] `fix` — Correção de bug
- [ ] `feat` — Nova funcionalidade
- [ ] `refactor` — Refatoração sem mudança de comportamento
- [ ] `style` — Ajustes de estilo/CSS (sem lógica)
- [ ] `test` — Adição ou correção de testes
- [ ] `docs` — Documentação
- [ ] `chore` — Manutenção, dependências, config

## Issue relacionada

<!-- Referencia a issue que este PR resolve. Ex: Closes #42 -->

Closes #

## Checklist — antes de solicitar review

### Qualidade de código

- [ ] O código segue os padrões do projeto (ESLint passa: `pnpm lint`)
- [ ] A formatação está correta (Prettier passa: `pnpm format:check`)
- [ ] Não há `console.log` ou código de debug esquecido
- [ ] Não há secrets ou variáveis de ambiente hardcoded

### Testes

- [ ] Os testes existentes continuam passando (`pnpm test:run`)
- [ ] Adicionei testes para a mudança implementada (quando aplicável)
- [ ] A cobertura de testes não regrediu (`pnpm test:coverage`)

### Build

- [ ] O build de produção passa sem erros (`pnpm build`)

### Componentes e UI (se aplicável)

- [ ] Testei nas variantes aplicáveis do `EventCard` (`variant="compact"` e `variant="full"`)
- [ ] Verifiquei responsividade (mobile, tablet, desktop)
- [ ] As variáveis CSS do projeto foram usadas (`--primary-blue`, `--surface`, `--background`, etc.)
- [ ] Não quebrei estilos de outras telas

### Dados e serviços (se aplicável)

- [ ] Chamadas ao Supabase usam `withRetry` de `apiClient.js`
- [ ] Datas estão no formato correto (`DD/MM/YYYY` para exibição, `YYYY-MM-DD` para input date nativo)
- [ ] Imports circulares foram evitados (usar import dinâmico quando necessário)

## Como testar

<!-- Passo a passo para o reviewer reproduzir e validar a mudança -->

1. Checkout nesta branch: `git checkout <nome-da-branch>`
2. Instalar dependências: `pnpm install`
3. Subir ambiente local: `pnpm dev`
4. Navegar até: `<!-- ex: /eventos ou /eventos/:id -->`
5. <!-- Descreva o que verificar -->

## Screenshots / Gravação (se aplicável)

<!-- Antes e depois para mudanças visuais. Arraste as imagens aqui ou cole do clipboard -->

| Antes | Depois |
| ----- | ------ |
|       |        |

## Contexto adicional

<!-- Qualquer informação extra que ajude o reviewer: decisões de design, trade-offs, limitações conhecidas, débito técnico gerado -->
